### PR TITLE
Keep standalone assets in sync

### DIFF
--- a/bin/bananatape.mjs
+++ b/bin/bananatape.mjs
@@ -152,14 +152,15 @@ async function buildExists() {
 async function standaloneServerExists() {
   return pathExists(path.join(APP_ROOT, '.next', 'standalone', 'server.js'));
 }
-async function copyIfMissing(source, destination) {
-  if (await pathExists(destination) || !(await pathExists(source))) return;
+async function syncDirectoryIfPresent(source, destination) {
+  if (!(await pathExists(source))) return;
+  await fs.rm(destination, { recursive: true, force: true });
   await fs.cp(source, destination, { recursive: true });
 }
 async function prepareStandaloneServer() {
   const standaloneRoot = path.join(APP_ROOT, '.next', 'standalone');
-  await copyIfMissing(path.join(APP_ROOT, '.next', 'static'), path.join(standaloneRoot, '.next', 'static'));
-  await copyIfMissing(path.join(APP_ROOT, 'public'), path.join(standaloneRoot, 'public'));
+  await syncDirectoryIfPresent(path.join(APP_ROOT, '.next', 'static'), path.join(standaloneRoot, '.next', 'static'));
+  await syncDirectoryIfPresent(path.join(APP_ROOT, 'public'), path.join(standaloneRoot, 'public'));
 }
 function spawnBrowser(url) {
   if (process.platform === 'darwin') return spawn('open', [url], { stdio: 'ignore', detached: true }).unref();

--- a/bin/bananatape.mjs
+++ b/bin/bananatape.mjs
@@ -7,7 +7,8 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const SCHEMA_VERSION = 1;
-const APP_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DEFAULT_APP_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const APP_ROOT = path.resolve(process.env.NODE_ENV === 'test' && process.env.BANANATAPE_TEST_APP_ROOT ? process.env.BANANATAPE_TEST_APP_ROOT : DEFAULT_APP_ROOT);
 
 function homeDir() { return os.homedir(); }
 function runtimeDir() { return path.resolve(process.env.BANANATAPE_HOME || path.join(homeDir(), '.bananatape')); }
@@ -154,8 +155,18 @@ async function standaloneServerExists() {
 }
 async function syncDirectoryIfPresent(source, destination) {
   if (!(await pathExists(source))) return;
-  await fs.rm(destination, { recursive: true, force: true });
-  await fs.cp(source, destination, { recursive: true });
+  const parent = path.dirname(destination);
+  const temporary = path.join(parent, `.${path.basename(destination)}-${process.pid}-${Date.now()}.tmp`);
+  await fs.mkdir(parent, { recursive: true });
+  await fs.rm(temporary, { recursive: true, force: true });
+  try {
+    await fs.cp(source, temporary, { recursive: true });
+    await fs.rm(destination, { recursive: true, force: true });
+    await fs.rename(temporary, destination);
+  } catch (error) {
+    await fs.rm(temporary, { recursive: true, force: true });
+    throw error;
+  }
 }
 async function prepareStandaloneServer() {
   const standaloneRoot = path.join(APP_ROOT, '.next', 'standalone');

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { access, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
@@ -147,6 +147,51 @@ describe('bananatape CLI project lifecycle', () => {
     const stoppedRuntime = JSON.parse(await readFile(path.join(home, 'runtime.json'), 'utf8'));
     expect(stoppedRuntime.running).toEqual([]);
   }, 20_000);
+
+  it('refreshes standalone static and public assets before launching', async () => {
+    const appRoot = await mkdtemp(path.join(os.tmpdir(), 'bananatape-app-root-'));
+    const standaloneRoot = path.join(appRoot, '.next', 'standalone');
+    const sourceStatic = path.join(appRoot, '.next', 'static', 'chunks');
+    const destinationStatic = path.join(standaloneRoot, '.next', 'static', 'chunks');
+    const sourcePublic = path.join(appRoot, 'public');
+    const destinationPublic = path.join(standaloneRoot, 'public');
+
+    await mkdir(sourceStatic, { recursive: true });
+    await mkdir(destinationStatic, { recursive: true });
+    await mkdir(sourcePublic, { recursive: true });
+    await mkdir(destinationPublic, { recursive: true });
+    await writeFile(path.join(appRoot, '.next', 'BUILD_ID'), 'test-build');
+    await writeFile(path.join(sourceStatic, 'current.js'), 'console.log("current")');
+    await writeFile(path.join(destinationStatic, 'stale.js'), 'console.log("stale")');
+    await writeFile(path.join(sourcePublic, 'current.txt'), 'current public');
+    await writeFile(path.join(destinationPublic, 'stale.txt'), 'stale public');
+    await writeFile(path.join(standaloneRoot, 'server.js'), `
+      const http = require('node:http');
+      const server = http.createServer((request, response) => {
+        response.end(request.url === '/api/projects/current' ? '{}' : 'ok');
+      });
+      server.listen(Number(process.env.PORT), process.env.HOSTNAME);
+      process.on('SIGTERM', () => server.close(() => process.exit(0)));
+    `);
+
+    env = {
+      ...env,
+      BANANATAPE_TEST_APP_ROOT: appRoot,
+    };
+    await runCli(['create', 'Asset Sync']);
+    const port = await freePort();
+
+    try {
+      await runCli(['launch', 'asset-sync', '--port', String(port), '--no-open']);
+      await expect(readFile(path.join(destinationStatic, 'current.js'), 'utf8')).resolves.toContain('current');
+      await expect(readFile(path.join(destinationStatic, 'stale.js'), 'utf8')).rejects.toThrow();
+      await expect(readFile(path.join(destinationPublic, 'current.txt'), 'utf8')).resolves.toBe('current public');
+      await expect(readFile(path.join(destinationPublic, 'stale.txt'), 'utf8')).rejects.toThrow();
+    } finally {
+      await runCli(['stop', 'asset-sync']);
+      await rm(appRoot, { recursive: true, force: true });
+    }
+  });
 
   it('rejects an occupied explicit launch port', async () => {
     await runCli(['create', 'Port Collision']);


### PR DESCRIPTION
The CLI launches the Next standalone server, which serves static files from the standalone tree rather than the repository-level .next/static directory. Sync the static and public directories on launch so packaged installs and rebuilds do not leave the browser with stale or missing hashed assets.

> Constraint: Next standalone output does not include .next/static or public by default

Rejected: Copy assets only when missing | rebuilds can leave stale hashed chunks in place

Confidence: `high`

Scope-risk: `narrow`

Directive: Keep standalone launch asset layout aligned with Next's standalone serving root

Tested: `npm run typecheck`

Tested: `npm run lint`

Tested: `npm run build`

Tested: `local CLI launch returned 200 for rendered page and all referenced /_next/static assets`