### PR TITLE
Show design context as locked markdown viewer

### DIFF
--- a/src/app/api/projects/design-context/route.ts
+++ b/src/app/api/projects/design-context/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from 'next/server';
+import { clearProjectDesignContext, setProjectDesignContext } from '@/lib/projects/metadata-store';
+import { requireProjectSession } from '@/lib/projects/session';
+
+export const runtime = 'nodejs';
+
+export const MAX_DESIGN_CONTEXT_BYTES = 256 * 1024;
+
+const ALLOWED_MIME_TYPES = new Set([
+  'text/markdown',
+  'text/x-markdown',
+  'text/plain',
+  'application/octet-stream',
+  '',
+]);
+
+function isFile(value: FormDataEntryValue | null): value is File {
+  return value instanceof File && value.size > 0;
+}
+
+function hasMarkdownExtension(name: string): boolean {
+  const lower = name.toLowerCase();
+  return lower.endsWith('.md') || lower.endsWith('.markdown');
+}
+
+function settingsResponse(settings: Awaited<ReturnType<typeof setProjectDesignContext>>) {
+  return NextResponse.json({
+    designContext: settings.designContext ?? '',
+    designContextFileName: settings.designContextFileName ?? '',
+  });
+}
+
+export async function POST(request: Request) {
+  try {
+    const session = requireProjectSession();
+    const formData = await request.formData();
+    const candidate = formData.get('designContext');
+    if (!isFile(candidate)) {
+      return NextResponse.json({ error: 'A markdown file is required' }, { status: 400 });
+    }
+    if (!hasMarkdownExtension(candidate.name) || !ALLOWED_MIME_TYPES.has(candidate.type)) {
+      return NextResponse.json(
+        { error: 'Design context must be a .md or .markdown file' },
+        { status: 400 },
+      );
+    }
+    if (candidate.size > MAX_DESIGN_CONTEXT_BYTES) {
+      return NextResponse.json(
+        { error: `Design context file must be smaller than ${Math.round(MAX_DESIGN_CONTEXT_BYTES / 1024)} KB` },
+        { status: 413 },
+      );
+    }
+
+    const content = await candidate.text();
+    const settings = await setProjectDesignContext(session.projectRoot, {
+      content,
+      fileName: candidate.name,
+    });
+    return settingsResponse(settings);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to update design context';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}
+
+export async function DELETE() {
+  try {
+    const session = requireProjectSession();
+    const settings = await clearProjectDesignContext(session.projectRoot);
+    return settingsResponse(settings);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to clear design context';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/components/Composer/PromptComposerProvider.tsx
+++ b/src/components/Composer/PromptComposerProvider.tsx
@@ -35,6 +35,10 @@ interface PromptComposerContextValue {
   referenceImages: ReferenceImage[];
   systemPrompt: string;
   setSystemPrompt: (prompt: string) => void;
+  designContext: string;
+  designContextFileName: string;
+  replaceDesignContext: (file: File) => Promise<void>;
+  clearDesignContext: () => Promise<void>;
   addReferenceFiles: (files: File[], source?: ReferenceSource) => Promise<void>;
   removeReferenceImage: (id: string) => void;
   clearReferenceImages: () => void;
@@ -43,6 +47,7 @@ interface PromptComposerContextValue {
   handleEdit: () => Promise<void>;
   canEdit: boolean;
   hasReferenceImages: boolean;
+  hasDesignContext: boolean;
 }
 
 const OPENAI_MAX_INPUT_IMAGES = 16;
@@ -55,6 +60,8 @@ export function PromptComposerProvider({ children }: { children: ReactNode }) {
   const [prompt, setPrompt] = useState('');
   const [referenceImages, setReferenceImages] = useState<ReferenceImage[]>([]);
   const [systemPrompt, setSystemPrompt] = useState('');
+  const [designContext, setDesignContext] = useState('');
+  const [designContextFileName, setDesignContextFileName] = useState('');
   const referenceImagesRef = useRef<ReferenceImage[]>([]);
   const didLoadProjectSettingsRef = useRef(false);
 
@@ -76,6 +83,7 @@ export function PromptComposerProvider({ children }: { children: ReactNode }) {
 
   const canEdit = !!baseImage;
   const hasReferenceImages = referenceImages.length > 0;
+  const hasDesignContext = designContext.trim().length > 0;
   const hasAnnotations = paths.length > 0 || boxes.length > 0 || memos.some((memo) => memo.text.trim());
 
   useEffect(() => {
@@ -101,6 +109,8 @@ export function PromptComposerProvider({ children }: { children: ReactNode }) {
         if (cancelled) return;
 
         setSystemPrompt(typeof settings.systemPrompt === 'string' ? settings.systemPrompt : '');
+        setDesignContext(typeof settings.designContext === 'string' ? settings.designContext : '');
+        setDesignContextFileName(typeof settings.designContextFileName === 'string' ? settings.designContextFileName : '');
 
         if (Array.isArray(settings.referenceImages)) {
           const persistedReferences = await Promise.all(settings.referenceImages.map(async (reference: {
@@ -261,19 +271,78 @@ export function PromptComposerProvider({ children }: { children: ReactNode }) {
     setPrompt('');
   }, []);
 
+  const replaceDesignContext = useCallback(async (file: File) => {
+    const lowerName = file.name.toLowerCase();
+    if (!lowerName.endsWith('.md') && !lowerName.endsWith('.markdown')) {
+      addToast('Design context must be a .md or .markdown file', 'error');
+      return;
+    }
+
+    let nextContent: string;
+    try {
+      nextContent = await file.text();
+    } catch {
+      addToast('Could not read the design context file', 'error');
+      return;
+    }
+
+    setDesignContext(nextContent);
+    setDesignContextFileName(file.name);
+
+    try {
+      const formData = new FormData();
+      formData.append('designContext', file, file.name);
+      const response = await fetch('/api/projects/design-context', {
+        method: 'POST',
+        body: formData,
+      });
+      if (!response.ok && response.status !== 404) {
+        const payload = await response.json().catch(() => ({}));
+        addToast(typeof payload?.error === 'string' ? payload.error : 'Could not save design context', 'error');
+        return;
+      }
+      if (response.ok) {
+        const payload = await response.json().catch(() => null);
+        if (payload && typeof payload.designContext === 'string') {
+          setDesignContext(payload.designContext);
+          setDesignContextFileName(typeof payload.designContextFileName === 'string' ? payload.designContextFileName : file.name);
+        }
+        addToast('Design context updated', 'success');
+      }
+    } catch {
+      // No-project/dev mode keeps the design context in memory only.
+    }
+  }, [addToast]);
+
+  const clearDesignContext = useCallback(async () => {
+    setDesignContext('');
+    setDesignContextFileName('');
+    try {
+      await fetch('/api/projects/design-context', { method: 'DELETE' });
+    } catch {
+      // No-project/dev mode keeps state in memory only.
+    }
+  }, []);
+
   const buildSubmittedPrompt = useCallback((fallbackPrompt?: string) => {
     const trimmedPrompt = prompt.trim() || fallbackPrompt?.trim() || '';
     const trimmedSystemPrompt = systemPrompt.trim();
+    const trimmedDesignContext = designContext.trim();
 
-    if (!trimmedSystemPrompt) {
+    if (!trimmedSystemPrompt && !trimmedDesignContext) {
       return trimmedPrompt;
     }
 
-    return [
-      `System prompt:\n${trimmedSystemPrompt}`,
-      `User prompt:\n${trimmedPrompt}`,
-    ].join('\n\n');
-  }, [prompt, systemPrompt]);
+    const sections: string[] = [];
+    if (trimmedDesignContext) {
+      sections.push(`Design context:\n${trimmedDesignContext}`);
+    }
+    if (trimmedSystemPrompt) {
+      sections.push(`System prompt:\n${trimmedSystemPrompt}`);
+    }
+    sections.push(`User prompt:\n${trimmedPrompt}`);
+    return sections.join('\n\n');
+  }, [designContext, prompt, systemPrompt]);
 
   const appendReferenceImages = useCallback((formData: FormData, fieldName: 'images' | 'referenceImages') => {
     referenceImages.forEach((reference, index) => {
@@ -452,6 +521,10 @@ export function PromptComposerProvider({ children }: { children: ReactNode }) {
     referenceImages,
     systemPrompt,
     setSystemPrompt,
+    designContext,
+    designContextFileName,
+    replaceDesignContext,
+    clearDesignContext,
     addReferenceFiles,
     removeReferenceImage,
     clearReferenceImages,
@@ -460,16 +533,22 @@ export function PromptComposerProvider({ children }: { children: ReactNode }) {
     handleEdit,
     canEdit,
     hasReferenceImages,
+    hasDesignContext,
   }), [
     addReferenceFiles,
     canEdit,
+    clearDesignContext,
     clearPromptComposer,
     clearReferenceImages,
+    designContext,
+    designContextFileName,
     handleEdit,
     handleGenerate,
+    hasDesignContext,
     hasReferenceImages,
     prompt,
     referenceImages,
+    replaceDesignContext,
     systemPrompt,
     setSystemPrompt,
     removeReferenceImage,

--- a/src/components/EditorLayout.tsx
+++ b/src/components/EditorLayout.tsx
@@ -67,6 +67,10 @@ function StandaloneEditorShell() {
     referenceImages,
     systemPrompt,
     setSystemPrompt,
+    designContext,
+    designContextFileName,
+    replaceDesignContext,
+    clearDesignContext,
     addReferenceFiles,
     removeReferenceImage,
     clearReferenceImages,
@@ -94,6 +98,10 @@ function StandaloneEditorShell() {
           onClearReferences={clearReferenceImages}
           systemPrompt={systemPrompt}
           onSystemPromptChange={setSystemPrompt}
+          designContext={designContext}
+          designContextFileName={designContextFileName}
+          onReplaceDesignContext={replaceDesignContext}
+          onClearDesignContext={clearDesignContext}
         />
         <main className="relative min-w-0 flex-1 overflow-hidden">
           <CanvasContainer className="h-full w-full" />

--- a/src/components/Sidebar/DesignContextViewer.tsx
+++ b/src/components/Sidebar/DesignContextViewer.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { Fragment, type ReactNode, useMemo } from 'react';
+import { cn } from '@/lib/utils';
+
+interface DesignContextViewerProps {
+  markdown: string;
+  className?: string;
+}
+
+type Block =
+  | { kind: 'heading'; level: 1 | 2 | 3 | 4; text: string }
+  | { kind: 'paragraph'; text: string }
+  | { kind: 'ul'; items: string[] }
+  | { kind: 'ol'; items: string[] }
+  | { kind: 'blockquote'; lines: string[] }
+  | { kind: 'code'; language: string; text: string }
+  | { kind: 'hr' };
+
+const HEADING_RE = /^(#{1,4})\s+(.+?)\s*#*\s*$/;
+const UL_RE = /^[-*+]\s+(.+)$/;
+const OL_RE = /^\d+\.\s+(.+)$/;
+const BLOCKQUOTE_RE = /^>\s?(.*)$/;
+const HR_RE = /^\s*(-{3,}|\*{3,}|_{3,})\s*$/;
+const FENCE_RE = /^```\s*([A-Za-z0-9_+-]*)\s*$/;
+
+function parseMarkdown(source: string): Block[] {
+  const lines = source.replace(/\r\n?/g, '\n').split('\n');
+  const blocks: Block[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    if (line.trim() === '') {
+      i += 1;
+      continue;
+    }
+
+    const fenceOpen = line.match(FENCE_RE);
+    if (fenceOpen) {
+      const language = (fenceOpen[1] ?? '').toLowerCase();
+      const buffer: string[] = [];
+      i += 1;
+      while (i < lines.length && !FENCE_RE.test(lines[i])) {
+        buffer.push(lines[i]);
+        i += 1;
+      }
+      if (i < lines.length) i += 1;
+      blocks.push({ kind: 'code', language, text: buffer.join('\n') });
+      continue;
+    }
+
+    if (HR_RE.test(line)) {
+      blocks.push({ kind: 'hr' });
+      i += 1;
+      continue;
+    }
+
+    const heading = line.match(HEADING_RE);
+    if (heading) {
+      const level = Math.min(heading[1].length, 4) as 1 | 2 | 3 | 4;
+      blocks.push({ kind: 'heading', level, text: heading[2] });
+      i += 1;
+      continue;
+    }
+
+    if (UL_RE.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length) {
+        const m = lines[i].match(UL_RE);
+        if (!m) break;
+        items.push(m[1]);
+        i += 1;
+      }
+      blocks.push({ kind: 'ul', items });
+      continue;
+    }
+
+    if (OL_RE.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length) {
+        const m = lines[i].match(OL_RE);
+        if (!m) break;
+        items.push(m[1]);
+        i += 1;
+      }
+      blocks.push({ kind: 'ol', items });
+      continue;
+    }
+
+    if (BLOCKQUOTE_RE.test(line)) {
+      const lineBuffer: string[] = [];
+      while (i < lines.length) {
+        const m = lines[i].match(BLOCKQUOTE_RE);
+        if (!m) break;
+        lineBuffer.push(m[1]);
+        i += 1;
+      }
+      blocks.push({ kind: 'blockquote', lines: lineBuffer });
+      continue;
+    }
+
+    const paragraphBuffer: string[] = [line];
+    i += 1;
+    while (i < lines.length) {
+      const next = lines[i];
+      if (
+        next.trim() === '' ||
+        HEADING_RE.test(next) ||
+        UL_RE.test(next) ||
+        OL_RE.test(next) ||
+        BLOCKQUOTE_RE.test(next) ||
+        HR_RE.test(next) ||
+        FENCE_RE.test(next)
+      ) {
+        break;
+      }
+      paragraphBuffer.push(next);
+      i += 1;
+    }
+    blocks.push({ kind: 'paragraph', text: paragraphBuffer.join(' ') });
+  }
+
+  return blocks;
+}
+
+// Tokenizer for inline markdown. Renders to a React fragment of escaped text +
+// styled spans. Never returns raw HTML, so XSS via injected tags is impossible:
+// every text segment ends up as a React string child, which React escapes.
+function renderInline(text: string, keyPrefix: string): ReactNode {
+  const nodes: ReactNode[] = [];
+  let buffer = '';
+  let i = 0;
+  let nodeKey = 0;
+
+  const flushText = () => {
+    if (buffer.length === 0) return;
+    nodes.push(<Fragment key={`${keyPrefix}-t${nodeKey++}`}>{buffer}</Fragment>);
+    buffer = '';
+  };
+
+  while (i < text.length) {
+    const rest = text.slice(i);
+
+    if (rest.startsWith('`')) {
+      const end = rest.indexOf('`', 1);
+      if (end > 0) {
+        flushText();
+        nodes.push(
+          <code key={`${keyPrefix}-c${nodeKey++}`} className="rounded bg-[#1e1e1e] px-1 py-0.5 text-[10.5px] text-[#86efac]">
+            {rest.slice(1, end)}
+          </code>,
+        );
+        i += end + 1;
+        continue;
+      }
+    }
+
+    if (rest.startsWith('**') || rest.startsWith('__')) {
+      const marker = rest.slice(0, 2);
+      const end = rest.indexOf(marker, 2);
+      if (end > 2) {
+        flushText();
+        nodes.push(
+          <strong key={`${keyPrefix}-b${nodeKey++}`} className="font-semibold text-[#f3f3f3]">
+            {renderInline(rest.slice(2, end), `${keyPrefix}-b${nodeKey}`)}
+          </strong>,
+        );
+        i += end + 2;
+        continue;
+      }
+    }
+
+    if ((rest.startsWith('*') && !rest.startsWith('**')) || (rest.startsWith('_') && !rest.startsWith('__'))) {
+      const marker = rest[0];
+      const end = rest.indexOf(marker, 1);
+      if (end > 1) {
+        flushText();
+        nodes.push(
+          <em key={`${keyPrefix}-i${nodeKey++}`} className="italic text-[#dcdcdc]">
+            {renderInline(rest.slice(1, end), `${keyPrefix}-i${nodeKey}`)}
+          </em>,
+        );
+        i += end + 1;
+        continue;
+      }
+    }
+
+    // Links: [text](url) — rendered as plain text "text (url)" because the
+    // viewer never produces clickable hrefs (no DOM attribute injection risk).
+    if (rest.startsWith('[')) {
+      const closeBracket = rest.indexOf(']');
+      if (closeBracket > 0 && rest[closeBracket + 1] === '(') {
+        const closeParen = rest.indexOf(')', closeBracket + 2);
+        if (closeParen > 0) {
+          const linkText = rest.slice(1, closeBracket);
+          const url = rest.slice(closeBracket + 2, closeParen).trim();
+          flushText();
+          nodes.push(
+            <Fragment key={`${keyPrefix}-l${nodeKey++}`}>
+              {linkText}
+              {url ? <span className="text-[#7a7a7a]"> ({url})</span> : null}
+            </Fragment>,
+          );
+          i += closeParen + 1;
+          continue;
+        }
+      }
+    }
+
+    buffer += text[i];
+    i += 1;
+  }
+
+  flushText();
+  return nodes.length > 0 ? <>{nodes}</> : null;
+}
+
+export function DesignContextViewer({ markdown, className }: DesignContextViewerProps) {
+  const blocks = useMemo(() => parseMarkdown(markdown), [markdown]);
+
+  return (
+    <div
+      data-testid="design-context-viewer"
+      role="region"
+      aria-label="Design context"
+      className={cn('select-text space-y-2 text-xs leading-5 text-[#cfcfcf]', className)}
+    >
+      {blocks.map((block, index) => {
+        const key = `block-${index}`;
+        switch (block.kind) {
+          case 'heading': {
+            const sizeClass = block.level === 1
+              ? 'text-sm font-semibold tracking-tight text-[#f3f3f3]'
+              : block.level === 2
+              ? 'text-[13px] font-semibold tracking-tight text-[#ededed]'
+              : block.level === 3
+              ? 'text-xs font-semibold uppercase tracking-wider text-[#cfcfcf]'
+              : 'text-[11px] font-semibold uppercase tracking-wider text-[#a8a8a8]';
+            const Tag = (`h${block.level}` as 'h1' | 'h2' | 'h3' | 'h4');
+            return (
+              <Tag key={key} className={cn('mt-3 first:mt-0', sizeClass)}>
+                {renderInline(block.text, key)}
+              </Tag>
+            );
+          }
+          case 'paragraph':
+            return (
+              <p key={key} className="text-[#cfcfcf]">
+                {renderInline(block.text, key)}
+              </p>
+            );
+          case 'ul':
+            return (
+              <ul key={key} className="ml-4 list-disc space-y-1 text-[#cfcfcf] marker:text-[#666]">
+                {block.items.map((item, itemIndex) => (
+                  <li key={`${key}-i${itemIndex}`}>{renderInline(item, `${key}-i${itemIndex}`)}</li>
+                ))}
+              </ul>
+            );
+          case 'ol':
+            return (
+              <ol key={key} className="ml-4 list-decimal space-y-1 text-[#cfcfcf] marker:text-[#666]">
+                {block.items.map((item, itemIndex) => (
+                  <li key={`${key}-i${itemIndex}`}>{renderInline(item, `${key}-i${itemIndex}`)}</li>
+                ))}
+              </ol>
+            );
+          case 'blockquote':
+            return (
+              <blockquote key={key} className="border-l-2 border-white/10 pl-2 text-[#9e9e9e]">
+                {block.lines.map((line, lineIndex) => (
+                  <p key={`${key}-l${lineIndex}`}>{renderInline(line, `${key}-l${lineIndex}`)}</p>
+                ))}
+              </blockquote>
+            );
+          case 'code':
+            return (
+              <pre
+                key={key}
+                className="overflow-x-auto rounded-md border border-white/10 bg-[#171717] p-2 text-[10.5px] leading-4 text-[#86efac]"
+                data-language={block.language || undefined}
+              >
+                <code>{block.text}</code>
+              </pre>
+            );
+          case 'hr':
+            return <hr key={key} className="my-3 border-white/10" />;
+          default:
+            return null;
+        }
+      })}
+    </div>
+  );
+}

--- a/src/components/Sidebar/LeftPanel.tsx
+++ b/src/components/Sidebar/LeftPanel.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useMemo, useRef, useState } from 'react';
-import { ImagePlus, Layers3, Palette, Sparkles, Trash2, X } from 'lucide-react';
+import { FileText, ImagePlus, Layers3, Lock, Palette, Sparkles, Trash2, Upload, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { useEditorStore } from '@/stores/useEditorStore';
 import { cn } from '@/lib/utils';
 import type { ReferenceImagePreview } from '@/components/Composer/types';
+import { DesignContextViewer } from './DesignContextViewer';
 
 interface LeftPanelProps {
   references: ReferenceImagePreview[];
@@ -15,6 +16,10 @@ interface LeftPanelProps {
   onClearReferences: () => void;
   systemPrompt: string;
   onSystemPromptChange: (value: string) => void;
+  designContext: string;
+  designContextFileName: string;
+  onReplaceDesignContext: (file: File) => void | Promise<void>;
+  onClearDesignContext: () => void | Promise<void>;
   className?: string;
 }
 
@@ -32,10 +37,15 @@ export function LeftPanel({
   onClearReferences,
   systemPrompt,
   onSystemPromptChange,
+  designContext,
+  designContextFileName,
+  onReplaceDesignContext,
+  onClearDesignContext,
   className,
 }: LeftPanelProps) {
   const [tab, setTab] = useState<'context' | 'styles'>('context');
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const designFileInputRef = useRef<HTMLInputElement | null>(null);
   const paths = useEditorStore((s) => s.paths);
   const boxes = useEditorStore((s) => s.boxes);
   const memos = useEditorStore((s) => s.memos);
@@ -50,6 +60,7 @@ export function LeftPanel({
   ], [baseImage, boxes.length, memos.length, paths.length]);
 
   const annotationCount = paths.length + boxes.length + memos.length;
+  const hasDesignContext = designContext.trim().length > 0;
 
   return (
     <aside
@@ -75,6 +86,83 @@ export function LeftPanel({
 
       {tab === 'context' ? (
         <div className="flex-1 overflow-y-auto py-2">
+          <section data-testid="design-context-section" className="border-b border-[#1e1e1e] px-3 py-2">
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-wider text-[#999]">
+                <Lock className="h-3 w-3" />
+                Design System
+                {hasDesignContext && (
+                  <span className="rounded bg-[#14351f] px-1.5 py-0.5 text-[9px] normal-case tracking-normal text-[#86efac]">
+                    applied
+                  </span>
+                )}
+              </div>
+              {hasDesignContext && (
+                <button
+                  type="button"
+                  className="text-[10px] text-[#808080] hover:text-white"
+                  onClick={() => void onClearDesignContext()}
+                  data-testid="design-context-clear"
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+            <input
+              ref={designFileInputRef}
+              type="file"
+              accept=".md,.markdown,text/markdown,text/plain"
+              className="hidden"
+              data-testid="design-context-file-input"
+              onChange={(event) => {
+                const file = event.target.files?.[0];
+                if (file) void onReplaceDesignContext(file);
+                event.currentTarget.value = '';
+              }}
+            />
+            {hasDesignContext ? (
+              <div className="space-y-2">
+                <div className="flex items-center gap-1.5 text-[10px] text-[#a8a8a8]">
+                  <FileText className="h-3 w-3 shrink-0" />
+                  <span className="truncate" title={designContextFileName || 'DESIGN.md'}>
+                    {designContextFileName || 'DESIGN.md'}
+                  </span>
+                </div>
+                <div
+                  data-testid="design-context-content"
+                  className="max-h-64 overflow-y-auto rounded-lg border border-white/10 bg-[#1e1e1e] p-2.5"
+                >
+                  <DesignContextViewer markdown={designContext} />
+                </div>
+                <Button
+                  type="button"
+                  size="xs"
+                  variant="secondary"
+                  className="w-full justify-center bg-[#2a2a2a] text-[10px] text-[#cfcfcf] hover:bg-[#3b3b3b]"
+                  onClick={() => designFileInputRef.current?.click()}
+                  data-testid="design-context-replace"
+                >
+                  <Upload className="h-3 w-3" />
+                  Replace
+                </Button>
+                <p className="text-[10px] leading-4 text-[#808080]">
+                  Read-only. Replace by uploading a new <code className="rounded bg-[#1e1e1e] px-1 text-[#cfcfcf]">.md</code> file.
+                </p>
+              </div>
+            ) : (
+              <button
+                type="button"
+                className="flex h-24 w-full flex-col items-center justify-center gap-1 rounded-lg border border-dashed border-white/15 bg-[#1e1e1e] text-xs text-[#808080] hover:border-[#0d99ff]/60 hover:text-[#e6e6e6]"
+                onClick={() => designFileInputRef.current?.click()}
+                data-testid="design-context-upload"
+              >
+                <Lock className="h-4 w-4" />
+                <span>Upload DESIGN.md</span>
+                <span className="text-[10px] text-[#666]">.md or .markdown</span>
+              </button>
+            )}
+          </section>
+
           <section className="border-b border-[#1e1e1e] px-3 py-2">
             <div className="mb-2 flex items-center gap-2 text-[10px] font-semibold uppercase tracking-wider text-[#999]">
               <Sparkles className="h-3 w-3" />

--- a/src/lib/projects/metadata-store.ts
+++ b/src/lib/projects/metadata-store.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, rename, open } from 'node:fs/promises';
 import path from 'node:path';
 import { nanoid } from 'nanoid';
 import type { Provider } from '@/types';
-import { createEmptyHistory, createEmptyProjectSettings, HISTORY_SCHEMA_VERSION, isProjectHistory, normalizeProjectSettings, PROJECT_SCHEMA_VERSION, type ProjectHistory, type ProjectHistoryEntry, type ProjectManifest, type ProjectReferenceImage, type ProjectResultType, type ProjectSettings } from './schema';
+import { createEmptyHistory, createEmptyProjectSettings, HISTORY_SCHEMA_VERSION, isProjectHistory, normalizeProjectSettings, PROJECT_SCHEMA_VERSION, type ProjectHistory, type ProjectHistoryEntry, type ProjectManifest, type ProjectReferenceImage, type ProjectResultType, type ProjectSettings, type ProjectSettingsPatch } from './schema';
 import { ensureProjectDirectories, getHistoryPath, getManifestPath } from './paths';
 import { withProjectLock } from './locks';
 import { sanitizeProjectName, slugifyProjectName } from './validate';
@@ -78,7 +78,7 @@ async function updateProjectManifest(
 
 export async function updateProjectSettings(
   projectRoot: string,
-  patch: Partial<Pick<ProjectSettings, 'systemPrompt'>>,
+  patch: ProjectSettingsPatch,
 ): Promise<ProjectSettings> {
   const manifest = await updateProjectManifest(projectRoot, (current) => ({
     ...current,
@@ -88,6 +88,28 @@ export async function updateProjectSettings(
     },
   }));
   return normalizeProjectSettings(manifest.settings);
+}
+
+export interface DesignContextInput {
+  content: string;
+  fileName: string;
+}
+
+export async function setProjectDesignContext(
+  projectRoot: string,
+  input: DesignContextInput,
+): Promise<ProjectSettings> {
+  return updateProjectSettings(projectRoot, {
+    designContext: input.content,
+    designContextFileName: input.fileName,
+  });
+}
+
+export async function clearProjectDesignContext(projectRoot: string): Promise<ProjectSettings> {
+  return updateProjectSettings(projectRoot, {
+    designContext: '',
+    designContextFileName: '',
+  });
 }
 
 export async function appendProjectReference(projectRoot: string, reference: ProjectReferenceImage): Promise<ProjectSettings> {

--- a/src/lib/projects/schema.ts
+++ b/src/lib/projects/schema.ts
@@ -26,7 +26,18 @@ export interface ProjectReferenceImage {
 export interface ProjectSettings {
   systemPrompt: string;
   referenceImages: ProjectReferenceImage[];
+  // Locked markdown loaded from DESIGN.md upload. Replaced only via the
+  // /api/projects/design-context endpoint; never written through PUT settings.
+  // Optional so legacy project.json files round-trip unchanged.
+  designContext?: string;
+  designContextFileName?: string;
 }
+
+// Narrow on purpose: do not widen to Partial<ProjectSettings> or callers can
+// silently overwrite referenceImages or future read-only fields.
+export type ProjectSettingsPatch = Partial<
+  Pick<ProjectSettings, 'systemPrompt' | 'designContext' | 'designContextFileName'>
+>;
 
 export interface ProjectHistoryEntry {
   id: string;
@@ -57,11 +68,19 @@ export function createEmptyProjectSettings(): ProjectSettings {
 }
 
 export function normalizeProjectSettings(settings: ProjectManifest['settings']): ProjectSettings {
-  return {
+  const normalized: ProjectSettings = {
     ...createEmptyProjectSettings(),
     ...(settings ?? {}),
     referenceImages: Array.isArray(settings?.referenceImages) ? settings.referenceImages : [],
   };
+
+  if (typeof normalized.designContext !== 'string' || normalized.designContext.length === 0) {
+    delete normalized.designContext;
+  }
+  if (typeof normalized.designContextFileName !== 'string' || normalized.designContextFileName.length === 0) {
+    delete normalized.designContextFileName;
+  }
+  return normalized;
 }
 
 export function createEmptyHistory(): ProjectHistory {

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -210,6 +210,134 @@ test.describe('BananaTape Editor', () => {
     await expect(page.locator('[data-testid="composer-reference-list"]')).toBeVisible();
   });
 
+  test('shows the design system upload guidance when no design context is set', async ({ page }) => {
+    const section = page.locator('[data-testid="design-context-section"]');
+    await expect(section).toBeVisible();
+    await expect(section).toContainText(/Design System/i);
+    await expect(section.locator('[data-testid="design-context-upload"]')).toBeVisible();
+    await expect(section.locator('[data-testid="design-context-upload"]')).toContainText(/Upload DESIGN\.md/);
+    await expect(section.locator('[data-testid="design-context-content"]')).toHaveCount(0);
+    await expect(section.getByText(/applied/i)).toHaveCount(0);
+  });
+
+  test('renders an uploaded DESIGN.md as read-only markdown with lock affordance', async ({ page }) => {
+    let nextDesignContext = '# Brand voice\n\n- Be **bold**.\n- Stay _consistent_.\n\nUse `bananatape` everywhere.';
+    let nextFileName = 'DESIGN.md';
+
+    await page.route('/api/projects/design-context', async (route) => {
+      const method = route.request().method();
+      if (method === 'POST') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            designContext: nextDesignContext,
+            designContextFileName: nextFileName,
+          }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ designContext: '', designContextFileName: '' }),
+      });
+    });
+
+    const section = page.locator('[data-testid="design-context-section"]');
+    await section.locator('[data-testid="design-context-file-input"]').setInputFiles({
+      name: 'DESIGN.md',
+      mimeType: 'text/markdown',
+      buffer: Buffer.from(nextDesignContext, 'utf-8'),
+    });
+
+    const viewer = section.locator('[data-testid="design-context-viewer"]');
+    await expect(viewer).toBeVisible();
+    await expect(viewer.locator('h1')).toHaveText('Brand voice');
+    await expect(viewer.locator('strong')).toHaveText('bold');
+    await expect(viewer.locator('em')).toHaveText('consistent');
+    await expect(viewer.locator('ul li')).toHaveCount(2);
+    await expect(viewer.locator('code').first()).toHaveText('bananatape');
+
+    await expect(section.getByText('applied')).toBeVisible();
+    await expect(section.locator('[data-testid="design-context-replace"]')).toBeVisible();
+    await expect(section.getByText('DESIGN.md', { exact: true })).toBeVisible();
+
+    expect(await viewer.locator('script').count()).toBe(0);
+
+    nextDesignContext = '## Tone\n\n- Stay punchy.';
+    nextFileName = 'BRAND.md';
+    await section.locator('[data-testid="design-context-file-input"]').setInputFiles({
+      name: 'BRAND.md',
+      mimeType: 'text/markdown',
+      buffer: Buffer.from(nextDesignContext, 'utf-8'),
+    });
+
+    await expect(viewer.locator('h2')).toHaveText('Tone');
+    await expect(section.getByText('BRAND.md', { exact: true })).toBeVisible();
+  });
+
+  test('escapes raw HTML inside the design context payload (no XSS)', async ({ page }) => {
+    const malicious = '# Heading\n\n<script>window.__designContextPwned = true;</script>\n\n<img src=x onerror="window.__designContextImgPwned = true">';
+
+    await page.route('/api/projects/design-context', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          designContext: malicious,
+          designContextFileName: 'DESIGN.md',
+        }),
+      });
+    });
+
+    const section = page.locator('[data-testid="design-context-section"]');
+    await section.locator('[data-testid="design-context-file-input"]').setInputFiles({
+      name: 'DESIGN.md',
+      mimeType: 'text/markdown',
+      buffer: Buffer.from(malicious, 'utf-8'),
+    });
+
+    const viewer = section.locator('[data-testid="design-context-viewer"]');
+    await expect(viewer.locator('h1')).toHaveText('Heading');
+    await expect(viewer.locator('script')).toHaveCount(0);
+    await expect(viewer.locator('img')).toHaveCount(0);
+    expect(await viewer.textContent()).toContain('<script>');
+
+    const pwned = await page.evaluate(() => ({
+      script: (window as unknown as { __designContextPwned?: boolean }).__designContextPwned ?? false,
+      img: (window as unknown as { __designContextImgPwned?: boolean }).__designContextImgPwned ?? false,
+    }));
+    expect(pwned.script).toBe(false);
+    expect(pwned.img).toBe(false);
+  });
+
+  test('hydrates an existing design context from project settings', async ({ page }) => {
+    await page.route('/api/projects/settings', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            systemPrompt: '',
+            referenceImages: [],
+            designContext: '# Hydrated\n- ready',
+            designContextFileName: 'STORED.md',
+          }),
+        });
+        return;
+      }
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true }) });
+    });
+
+    await page.reload();
+
+    const section = page.locator('[data-testid="design-context-section"]');
+    await expect(section.locator('[data-testid="design-context-viewer"] h1')).toHaveText('Hydrated');
+    await expect(section.getByText('STORED.md', { exact: true })).toBeVisible();
+    await expect(section.getByText('applied')).toBeVisible();
+  });
+
   test('history panel scrolls when it has many persisted entries', async ({ page }) => {
     const entries = Array.from({ length: 24 }, (_, index) => ({
       id: `hist_${index}`,

--- a/tests/unit/design-context-viewer.test.tsx
+++ b/tests/unit/design-context-viewer.test.tsx
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+import { DesignContextViewer } from '@/components/Sidebar/DesignContextViewer';
+
+let mountedRoot: Root | null = null;
+let mountedContainer: HTMLElement | null = null;
+
+function render(markdown: string): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(<DesignContextViewer markdown={markdown} />);
+  });
+  mountedRoot = root;
+  mountedContainer = container;
+  return container;
+}
+
+afterEach(() => {
+  if (mountedRoot) {
+    act(() => {
+      mountedRoot!.unmount();
+    });
+  }
+  if (mountedContainer && mountedContainer.parentNode) {
+    mountedContainer.parentNode.removeChild(mountedContainer);
+  }
+  mountedRoot = null;
+  mountedContainer = null;
+});
+
+describe('DesignContextViewer markdown rendering', () => {
+  it('renders ATX headings as h1..h4', () => {
+    const container = render('# H1\n## H2\n### H3\n#### H4');
+    expect(container.querySelector('h1')?.textContent).toBe('H1');
+    expect(container.querySelector('h2')?.textContent).toBe('H2');
+    expect(container.querySelector('h3')?.textContent).toBe('H3');
+    expect(container.querySelector('h4')?.textContent).toBe('H4');
+  });
+
+  it('renders unordered lists with one li per dash item', () => {
+    const container = render('- alpha\n- beta\n- gamma');
+    const items = container.querySelectorAll('ul > li');
+    expect(items).toHaveLength(3);
+    expect(items[0].textContent).toBe('alpha');
+    expect(items[2].textContent).toBe('gamma');
+  });
+
+  it('renders ordered lists with one li per numbered item', () => {
+    const container = render('1. first\n2. second');
+    const ol = container.querySelector('ol');
+    expect(ol).toBeTruthy();
+    const items = ol!.querySelectorAll('li');
+    expect(items).toHaveLength(2);
+    expect(items[0].textContent).toBe('first');
+  });
+
+  it('renders bold and italic inline tokens', () => {
+    const container = render('A **bold** and _italic_ word.');
+    expect(container.querySelector('strong')?.textContent).toBe('bold');
+    expect(container.querySelector('em')?.textContent).toBe('italic');
+  });
+
+  it('renders inline code spans', () => {
+    const container = render('Use `pnpm install` to start.');
+    const code = container.querySelector('code');
+    expect(code).toBeTruthy();
+    expect(code?.textContent).toBe('pnpm install');
+  });
+
+  it('renders fenced code blocks as pre/code', () => {
+    const container = render('```ts\nconst x = 1;\n```');
+    const pre = container.querySelector('pre');
+    expect(pre).toBeTruthy();
+    expect(pre?.getAttribute('data-language')).toBe('ts');
+    expect(pre?.querySelector('code')?.textContent).toBe('const x = 1;');
+  });
+
+  it('renders blockquotes and horizontal rules', () => {
+    const container = render('> note one\n> note two\n\n---');
+    expect(container.querySelector('blockquote')).toBeTruthy();
+    expect(container.querySelector('blockquote')?.textContent).toContain('note one');
+    expect(container.querySelector('hr')).toBeTruthy();
+  });
+
+  it('renders markdown links as plain text plus URL hint, never as a real <a> href', () => {
+    const container = render('See [the docs](https://example.com/) please.');
+    expect(container.querySelector('a')).toBeNull();
+    expect(container.textContent).toContain('the docs');
+    expect(container.textContent).toContain('(https://example.com/)');
+  });
+
+  it('refuses to interpret raw HTML script tags injected through the markdown payload (XSS)', () => {
+    const malicious = '# Heading\n\n<script>window.__pwned = true;</script>\n\nbody text';
+    const container = render(malicious);
+    expect(container.querySelector('script')).toBeNull();
+    expect((window as unknown as { __pwned?: boolean }).__pwned).toBeUndefined();
+    expect(container.textContent).toContain('<script>');
+    expect(container.textContent).toContain('window.__pwned = true;');
+  });
+
+  it('does not render raw HTML img onerror payloads as DOM elements', () => {
+    const malicious = '<img src=x onerror="window.__imgPwned = true">';
+    const container = render(malicious);
+    expect(container.querySelector('img')).toBeNull();
+    expect((window as unknown as { __imgPwned?: boolean }).__imgPwned).toBeUndefined();
+    expect(container.textContent).toContain('<img');
+  });
+
+  it('does not turn javascript: links into clickable anchors', () => {
+    const container = render('[oops](javascript:alert(1))');
+    expect(container.querySelector('a')).toBeNull();
+    expect(container.textContent).toContain('oops');
+    expect(container.textContent).toContain('javascript:alert(1)');
+  });
+});

--- a/tests/unit/design-context.test.ts
+++ b/tests/unit/design-context.test.ts
@@ -1,0 +1,96 @@
+import { mkdtemp } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  clearProjectDesignContext,
+  createProject,
+  readProjectSettings,
+  setProjectDesignContext,
+  updateProjectSettings,
+} from '@/lib/projects/metadata-store';
+import {
+  createEmptyProjectSettings,
+  normalizeProjectSettings,
+} from '@/lib/projects/schema';
+
+async function tempProjectRoot() {
+  return mkdtemp(path.join(os.tmpdir(), 'bananatape-design-context-test-'));
+}
+
+describe('design context schema', () => {
+  it('omits designContext fields from empty settings so legacy project.json still round-trips', () => {
+    const empty = createEmptyProjectSettings();
+    expect(empty).toEqual({ systemPrompt: '', referenceImages: [] });
+    expect('designContext' in empty).toBe(false);
+    expect('designContextFileName' in empty).toBe(false);
+  });
+
+  it('drops empty-string designContext fields during normalization', () => {
+    const normalized = normalizeProjectSettings({
+      systemPrompt: '',
+      referenceImages: [],
+      designContext: '',
+      designContextFileName: '',
+    });
+    expect(normalized).toEqual({ systemPrompt: '', referenceImages: [] });
+  });
+
+  it('preserves non-empty designContext fields during normalization', () => {
+    const normalized = normalizeProjectSettings({
+      systemPrompt: '',
+      referenceImages: [],
+      designContext: '# Title\n- one',
+      designContextFileName: 'DESIGN.md',
+    });
+    expect(normalized).toEqual({
+      systemPrompt: '',
+      referenceImages: [],
+      designContext: '# Title\n- one',
+      designContextFileName: 'DESIGN.md',
+    });
+  });
+});
+
+describe('design context store helpers', () => {
+  it('persists and clears design context through dedicated helpers', async () => {
+    const projectRoot = await tempProjectRoot();
+    await createProject(projectRoot, 'Design Context Test');
+
+    const initial = await readProjectSettings(projectRoot);
+    expect(initial.designContext).toBeUndefined();
+    expect(initial.designContextFileName).toBeUndefined();
+
+    const afterSet = await setProjectDesignContext(projectRoot, {
+      content: '# Brand\n- Use bananas, never mangoes.',
+      fileName: 'DESIGN.md',
+    });
+    expect(afterSet.designContext).toBe('# Brand\n- Use bananas, never mangoes.');
+    expect(afterSet.designContextFileName).toBe('DESIGN.md');
+
+    const reread = await readProjectSettings(projectRoot);
+    expect(reread.designContext).toBe('# Brand\n- Use bananas, never mangoes.');
+    expect(reread.designContextFileName).toBe('DESIGN.md');
+
+    const afterClear = await clearProjectDesignContext(projectRoot);
+    expect(afterClear.designContext).toBeUndefined();
+    expect(afterClear.designContextFileName).toBeUndefined();
+  });
+
+  it('updates only the fields named in the patch and leaves the design context alone', async () => {
+    const projectRoot = await tempProjectRoot();
+    await createProject(projectRoot, 'Patch Isolation');
+
+    await setProjectDesignContext(projectRoot, {
+      content: '# Locked\n- Do not delete me.',
+      fileName: 'LOCKED.md',
+    });
+
+    await updateProjectSettings(projectRoot, { systemPrompt: 'Always stay punchy.' });
+
+    const settings = await readProjectSettings(projectRoot);
+    expect(settings.systemPrompt).toBe('Always stay punchy.');
+    expect(settings.designContext).toBe('# Locked\n- Do not delete me.');
+    expect(settings.designContextFileName).toBe('LOCKED.md');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a read-only **Design System** section at the top of the Context tab in the left panel. Once a `DESIGN.md` is uploaded the section shows the file name, a rendered markdown preview, and a Replace button. When no design context is set the section shows an upload-guidance card instead. A lock icon is always visible so it is obvious the content is enforced and cannot be edited inline.

Implements issue #6 plus the minimum issue #5 plumbing the viewer needs to function.

## What changed

- **`src/lib/projects/schema.ts`** - adds optional `designContext` and `designContextFileName` to `ProjectSettings` and a narrow `ProjectSettingsPatch` type. `normalizeProjectSettings` drops the fields when empty so legacy `project.json` files round-trip unchanged.
- **`src/lib/projects/metadata-store.ts`** - widens `updateProjectSettings` to accept the new patch type and adds `setProjectDesignContext` / `clearProjectDesignContext` helpers that reuse the existing per-project lock.
- **`src/app/api/projects/design-context/route.ts`** (new) - `POST` accepts a `.md` / `.markdown` file up to 256 KB and persists it; `DELETE` clears the field. `PUT /api/projects/settings` is intentionally NOT extended so the design context cannot be silently overwritten through the regular settings PUT.
- **`src/components/Composer/PromptComposerProvider.tsx`** - hydrates the design context from settings, exposes `replaceDesignContext` / `clearDesignContext`, and prepends the design context to the assembled prompt when set so the **applied** badge is truthful. Behavior is unchanged when no design context is loaded.
- **`src/components/Sidebar/DesignContextViewer.tsx`** (new) - small custom markdown renderer that emits a React tree of escaped strings + styled spans. No external markdown deps, no `dangerouslySetInnerHTML`, and links render as plain ``text (url)`` so XSS via injected tags or ``javascript:`` hrefs is structurally impossible. Supports headings (h1-h4), unordered and ordered lists, bold, italic, inline code, fenced code blocks, blockquotes, and horizontal rules.
- **`src/components/Sidebar/LeftPanel.tsx`** - adds the Design System section with Lock icon, applied badge, scrollable viewer (``max-h-64`` with internal scroll), Replace button, Clear shortcut, and an upload guidance card that matches the existing references upload styling.
- **`src/components/EditorLayout.tsx`** - threads the new design-context props into `<LeftPanel>`.

## Tests

- **`tests/unit/design-context.test.ts`** - schema normalization (empty fields stay omitted, populated fields persist) and store helpers (`setProjectDesignContext` / `clearProjectDesignContext`, plus a regression test that confirms `updateProjectSettings({ systemPrompt })` no longer wipes the design context).
- **`tests/unit/design-context-viewer.test.tsx`** - renderer behavior for headings, ordered/unordered lists, bold, italic, inline code, fenced code, blockquote, hr, and link plain-text rendering. Three explicit XSS regression tests verify that `<script>` tags, `<img onerror>` payloads, and ``javascript:`` link hrefs are rendered as literal text and never produce DOM nodes that execute.
- **`tests/e2e/editor.spec.ts`** - 4 new Playwright cases:
  1. Empty state shows the upload guidance and no applied badge.
  2. Uploading ``DESIGN.md`` renders headings, bold, italic, list items, and code; replacing it swaps in the new content and file name.
  3. Raw HTML in the design context payload is escaped (no ``<script>``/``<img>`` in the DOM, no ``window.__pwned`` flag set).
  4. Hydrating an existing design context from ``GET /api/projects/settings`` populates the viewer on page load.

## Verification

Run from the worktree at ``/Users/jeffrey/Projects/bananatape-issue-6``:

| Step | Result |
| --- | --- |
| ``npm run lint`` | 0 errors, 2 pre-existing warnings (unrelated `<img>` usage) |
| ``npm run typecheck`` | clean |
| ``npx vitest run`` | 48/48 pass (incl. 11 new) |
| ``npx playwright test`` | 30 passing (incl. 4 new); 2 pre-existing flaky tests (clipboard paste + provider menu) pass on retry, untouched by this PR |
| ``npm run build`` | success, ``/api/projects/design-context`` route registered |
| Manual API curl | upload, ``.exe`` rejected (400), 300 KB rejected (413), DELETE clears, GET returns clean shape |
| Manual UI screenshots | empty + populated states render exactly per the issue acceptance criteria |

## Acceptance criteria from #6

- [x] Headings, lists, bold, italic render in the markdown preview when a design context is set
- [x] Lock icon next to the section title (and inside the empty-state guidance)
- [x] Content area is read-only (rendered as ``<div role="region">``, no caret, no textarea)
- [x] Replace button uploads a new ``.md`` file
- [x] Upload guidance shown when no design context is loaded
- [x] XSS prevented (renderer never produces raw HTML; e2e + unit tests cover script/img/javascript: payloads)
- [x] Long specs scroll inside the panel without breaking layout (``max-h-64 overflow-y-auto`` viewer container)

Closes #6.