### PR TITLE
Add Live2D post-generation auto-intake

### DIFF
--- a/docs/live2d-auto-intake-pr-plan.md
+++ b/docs/live2d-auto-intake-pr-plan.md
@@ -1,0 +1,147 @@
+# Live2D Auto-Intake PR Plan
+
+## Conclusion
+
+BananaTape currently stops after image generation: the generated Live2D part sheet appears on the canvas, but the project does not automatically advance into Live2D intake. This PR should add the missing orchestration layer: after a Live2D-oriented generation completes, BananaTape should run a deterministic local auto-intake pass that detects the boxed part-sheet layout, proposes labeled part crops, writes the Live2D handoff manifest, and surfaces the result for review.
+
+This PR must not claim full Cubism rigging, `.moc3` generation, or perfect semantic segmentation. It should deliver a reviewable MVP that turns a generated grid-style reference sheet into a concrete `live2d/manifest.json` draft with candidate boxes.
+
+## Non-goals
+
+- No Cubism Editor automation.
+- No `.moc3`, `.model3.json`, physics, mesh, deformer, expression, or motion export.
+- No hard dependency on cloud VLM/OCR APIs.
+- No promise that arbitrary character images can be segmented.
+- No destructive modification of generated assets.
+
+## Exact PR scope
+
+Implement a deterministic Live2D auto-intake MVP inside BananaTape:
+
+1. Add a local Live2D auto-intake module that accepts an image size and, for the current generated sheet layout, proposes normalized bbox annotations for the right-side part grid.
+2. Use a stable numbered part taxonomy mapping for the 26-box prompt/reference-sheet format.
+3. Add an API route that runs auto-intake for the current project and selected history asset, persists `live2d/manifest.json`, and updates project Live2D settings to select that asset.
+4. Hook generation completion so when Live2D mode is enabled, BananaTape automatically calls the auto-intake route after saving a generated image.
+5. Add concise UI/status copy so the user sees that Live2D intake candidates were created and need review, rather than thinking a finished Live2D model was created.
+6. Add focused unit tests for the detector/mapping and route-level behavior.
+
+## Architecture
+
+### Existing surfaces to preserve
+
+- `src/lib/live2d/contract.ts` owns Live2D prompt preset, manifest types, and manifest builders.
+- `src/app/api/projects/live2d/manifest/route.ts` already writes the manual Live2D handoff manifest.
+- `src/lib/projects/metadata-store.ts` persists project settings/history.
+- The editor store/provider path already saves generation history entries.
+
+### New surfaces
+
+Suggested files:
+
+```text
+src/lib/live2d/auto-intake.ts
+src/app/api/projects/live2d/auto-intake/route.ts
+tests/unit/live2d-auto-intake.test.ts
+```
+
+`auto-intake.ts` should expose pure functions such as:
+
+```ts
+export const LIVE2D_REFERENCE_SHEET_PARTS = [...]
+export function proposeReferenceSheetGridAnnotations(options: {
+  imageWidth: number
+  imageHeight: number
+}): Live2DAnnotation[]
+```
+
+For MVP, use the known layout contract from the prompt:
+
+- left side: assembled preview
+- right side: 26 boxed parts
+- boxes sorted row-major
+- labels/numbers map to stable part names
+
+The function should generate normalized bounding boxes that cover the expected right-side grid cells. Keep it deterministic and testable. If image dimensions are missing or invalid, return a clear failure instead of guessing.
+
+### API route
+
+`POST /api/projects/live2d/auto-intake`
+
+Payload:
+
+```json
+{
+  "historyEntryId": "optional selected generation id",
+  "imageWidth": 1536,
+  "imageHeight": 1024
+}
+```
+
+Behavior:
+
+1. Resolve the current project.
+2. Select the requested history entry or latest image generation entry.
+3. Generate candidate annotations via `proposeReferenceSheetGridAnnotations`.
+4. Build a `Live2DManifest` with selected asset + annotations.
+5. Write `live2d/manifest.json` through the existing manifest persistence path or equivalent project store API.
+6. Update project settings: `live2d.enabled = true`, `selectedHistoryEntryId = selected entry id`.
+7. Return JSON summary: selected id, annotation count, detected parts, reviewRequired true.
+
+### Generation hook
+
+After successful generation saves a history entry and updates the canvas, if Live2D mode/settings are enabled or the active/system prompt includes the Live2D reference-sheet preset, call the auto-intake endpoint.
+
+Do not block image display on auto-intake failure. Surface a warning/toast/status if auto-intake fails.
+
+### UI/status
+
+Use blunt copy:
+
+- Success: `Live2D intake draft created: 26 candidate part boxes. Review labels before export.`
+- Failure: `Image generated, but Live2D auto-intake failed. You can annotate boxes manually.`
+
+## Acceptance criteria
+
+- A generated Live2D reference sheet no longer leaves the user at a dead end; BananaTape creates a `live2d/manifest.json` draft automatically.
+- Candidate annotations use the repo's Live2D taxonomy names, not only generic labels.
+- The route returns `reviewRequired: true` and never claims finished rigging.
+- Existing manual manifest route still works.
+- Unit tests cover:
+  - 26 deterministic bbox proposals for a 1536x1024 style sheet.
+  - row-major numbered part mapping.
+  - route or store behavior that persists selected asset + annotations.
+- Verification commands pass:
+  - `npx vitest run tests/unit/live2d-auto-intake.test.ts tests/unit/projects.test.ts`
+  - `npm run typecheck`
+
+## Risks
+
+- The detector is layout-contract-based, not a general image segmentation model. This is intentional for MVP.
+- If generated sheets do not follow the prompt's strict grid layout, candidates may need manual correction.
+- Real production quality still needs later stages: actual box edge detection, OCR/VLM label confidence, background removal, part crop export, and Cubism rigging.
+
+## OMX implementation prompt
+
+Use this prompt exactly:
+
+```text
+Task: bananatape-live2d-auto-intake-20260430.
+
+You are implementing a focused GitHub PR in /tmp/bananatape-live2d-auto-intake. First read docs/live2d-auto-intake-pr-plan.md and follow it exactly.
+
+Goal: add the missing BananaTape Live2D post-generation auto-intake orchestration. After a Live2D part-sheet generation, BananaTape should automatically draft the Live2D handoff by proposing part bbox annotations for the known grid-style reference sheet and persisting live2d/manifest.json. Do not implement Cubism rigging, .moc3 generation, or a general segmentation model.
+
+Required implementation:
+1. Add a pure Live2D auto-intake module with the 26-part reference-sheet taxonomy and deterministic normalized bbox proposals for the strict grid layout.
+2. Add POST /api/projects/live2d/auto-intake to select the latest/requested generated history entry, create annotations, persist live2d/manifest.json, and set project live2d settings.
+3. Hook successful generation completion so Live2D mode or Live2D prompt preset triggers auto-intake without blocking image display.
+4. Add clear review-required status copy; never claim finished Live2D/Cubism model creation.
+5. Add focused unit tests for detector/mapping and persistence behavior.
+
+Verification:
+- npx vitest run tests/unit/live2d-auto-intake.test.ts tests/unit/projects.test.ts
+- npm run typecheck
+- git diff --stat origin/main...HEAD
+
+Commit all changes on the current branch with a clear lore-style commit message. Do not push main.
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1338,9 +1338,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1356,9 +1353,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1376,9 +1370,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1394,9 +1385,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1414,9 +1402,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1432,9 +1417,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1452,9 +1434,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1471,9 +1450,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1489,9 +1465,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1515,9 +1488,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1539,9 +1509,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1565,9 +1532,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1589,9 +1553,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1615,9 +1576,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1640,9 +1598,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1664,9 +1619,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2039,9 +1991,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2057,9 +2006,6 @@
       "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2077,9 +2023,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2095,9 +2038,6 @@
       "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2365,9 +2305,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2385,9 +2322,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2405,9 +2339,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2425,9 +2356,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2445,9 +2373,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2465,9 +2390,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2770,9 +2692,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2790,9 +2709,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2810,9 +2726,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2830,9 +2743,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3560,9 +3470,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3577,9 +3484,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3594,9 +3498,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3611,9 +3512,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3628,9 +3526,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3645,9 +3540,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3662,9 +3554,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3679,9 +3568,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6217,6 +6103,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7730,9 +7617,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7754,9 +7638,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7778,9 +7659,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7802,9 +7680,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1338,6 +1338,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1353,6 +1356,9 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1370,6 +1376,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1385,6 +1394,9 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1402,6 +1414,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1417,6 +1432,9 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1434,6 +1452,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1450,6 +1471,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1465,6 +1489,9 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1488,6 +1515,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1509,6 +1539,9 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1532,6 +1565,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1553,6 +1589,9 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1576,6 +1615,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1598,6 +1640,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1619,6 +1664,9 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1991,6 +2039,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2006,6 +2057,9 @@
       "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2023,6 +2077,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2038,6 +2095,9 @@
       "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2305,6 +2365,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2322,6 +2385,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2339,6 +2405,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2356,6 +2425,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2373,6 +2445,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2390,6 +2465,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2692,6 +2770,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2709,6 +2790,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2726,6 +2810,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2743,6 +2830,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3470,6 +3560,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3484,6 +3577,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3498,6 +3594,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3512,6 +3611,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3526,6 +3628,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3540,6 +3645,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3554,6 +3662,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3568,6 +3679,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6103,7 +6217,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7617,6 +7730,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7638,6 +7754,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7659,6 +7778,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7680,6 +7802,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -3,6 +3,8 @@ import { persistImageResult } from '@/lib/projects/asset-store';
 import { hasActiveProject, requireProjectSession } from '@/lib/projects/session';
 import { isSupportedReferenceImageType, SUPPORTED_REFERENCE_IMAGE_FORMAT_LABEL } from '@/lib/images/reference-image-formats';
 import { editImage as openaiEdit, generateImage as openaiGenerate } from '../../../lib/providers/openai-provider';
+import { shouldAutoIntakeLive2D } from '@/lib/live2d/auto-intake';
+import { readProjectSettings, writeLive2DAutoIntakeManifest } from '@/lib/projects/metadata-store';
 import { generateImage as godTiboGenerate } from '../../../lib/providers/god-tibo-provider';
 
 const OPENAI_MAX_INPUT_IMAGES = 16;
@@ -103,6 +105,28 @@ export async function POST(request: Request) {
       response.assetId = persisted.historyEntry.assetId;
       response.assetUrl = persisted.assetUrl;
       response.metadata = persisted.historyEntry;
+      try {
+        const settings = await readProjectSettings(projectSession.projectRoot);
+        if (shouldAutoIntakeLive2D(prompt, settings.live2d.enabled)) {
+          const autoIntake = await writeLive2DAutoIntakeManifest(projectSession.projectRoot, {
+            selectedHistoryEntryId: persisted.historyEntry.id,
+            imageWidth: 1536,
+            imageHeight: 1024,
+          });
+          response.live2dAutoIntake = {
+            annotationCount: autoIntake.annotationCount,
+            detectedParts: autoIntake.detectedParts,
+            reviewRequired: autoIntake.reviewRequired,
+            scopeNote: autoIntake.scopeNote,
+            message: `Live2D intake draft created: ${autoIntake.annotationCount} candidate part boxes. Review labels before export.`,
+          };
+        }
+      } catch (autoIntakeError) {
+        response.live2dAutoIntake = {
+          error: autoIntakeError instanceof Error ? autoIntakeError.message : 'Live2D auto-intake failed',
+          message: 'Image generated, but Live2D auto-intake failed. You can annotate boxes manually.',
+        };
+      }
     }
 
     return NextResponse.json(response);

--- a/src/app/api/projects/live2d/auto-intake/route.ts
+++ b/src/app/api/projects/live2d/auto-intake/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { writeLive2DAutoIntakeManifest } from '@/lib/projects/metadata-store';
+import { requireProjectSession } from '@/lib/projects/session';
+
+export const runtime = 'nodejs';
+
+export async function POST(request: Request) {
+  try {
+    const session = requireProjectSession();
+    const body = await request.json().catch(() => ({}));
+    const selectedHistoryEntryId = typeof body.selectedHistoryEntryId === 'string'
+      ? body.selectedHistoryEntryId
+      : null;
+    const imageWidth = Number(body.imageWidth ?? 1536);
+    const imageHeight = Number(body.imageHeight ?? 1024);
+    const result = await writeLive2DAutoIntakeManifest(session.projectRoot, {
+      selectedHistoryEntryId,
+      imageWidth,
+      imageHeight,
+    });
+    return NextResponse.json({
+      success: true,
+      ...result,
+      message: `Live2D intake draft created: ${result.annotationCount} candidate part boxes. Review labels before export.`,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to run Live2D auto-intake';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/projects/live2d/manifest/route.ts
+++ b/src/app/api/projects/live2d/manifest/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { enableLive2DMode, readProjectHistory, readProjectSettings, writeLive2DManifest } from '@/lib/projects/metadata-store';
+import { requireProjectSession } from '@/lib/projects/session';
+
+export const runtime = 'nodejs';
+
+export async function POST(request: Request) {
+  try {
+    const session = requireProjectSession();
+    const body = await request.json().catch(() => ({}));
+    const selectedHistoryEntryId = typeof body.selectedHistoryEntryId === 'string'
+      ? body.selectedHistoryEntryId
+      : null;
+    const manifest = await writeLive2DManifest(session.projectRoot, selectedHistoryEntryId);
+    return NextResponse.json({ success: true, manifest });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to write Live2D manifest';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}
+
+export async function PUT() {
+  try {
+    const session = requireProjectSession();
+    const settings = await enableLive2DMode(session.projectRoot);
+    return NextResponse.json({ success: true, settings });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to enable Live2D mode';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}
+
+export async function GET() {
+  try {
+    const session = requireProjectSession();
+    const [settings, history] = await Promise.all([
+      readProjectSettings(session.projectRoot),
+      readProjectHistory(session.projectRoot),
+    ]);
+    return NextResponse.json({
+      live2d: settings.live2d,
+      selectedHistoryEntryId: settings.live2d.selectedHistoryEntryId,
+      historyCount: history.entries.length,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'No active project';
+    return NextResponse.json({ error: message }, { status: 404 });
+  }
+}

--- a/src/app/api/projects/settings/route.ts
+++ b/src/app/api/projects/settings/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { readProjectSettings, updateProjectSettings } from '@/lib/projects/metadata-store';
+import { normalizeLive2DProjectSettings } from '@/lib/live2d/contract';
 import { requireProjectSession } from '@/lib/projects/session';
 
 export const runtime = 'nodejs';
@@ -31,6 +32,7 @@ export async function PUT(request: Request) {
     const body = await request.json();
     const settings = await updateProjectSettings(session.projectRoot, {
       systemPrompt: typeof body.systemPrompt === 'string' ? body.systemPrompt : '',
+      ...(body.live2d ? { live2d: normalizeLive2DProjectSettings(body.live2d) } : {}),
     });
     return NextResponse.json({
       ...settings,

--- a/src/components/Composer/PromptComposerProvider.tsx
+++ b/src/components/Composer/PromptComposerProvider.tsx
@@ -408,7 +408,11 @@ export function PromptComposerProvider({ children }: { children: ReactNode }) {
         setBaseImage(data.assetUrl ?? data.imageDataUrl, { width: 0, height: 0 });
         setMode('edit');
         clearPromptComposer();
-        addToast('Image generated successfully', 'success');
+        if (data.live2dAutoIntake?.message) {
+          addToast(data.live2dAutoIntake.message, data.live2dAutoIntake.error ? 'error' : 'success');
+        } else {
+          addToast('Image generated successfully', 'success');
+        }
       }
     } catch (e) {
       const message = e instanceof Error ? e.message : 'Generation failed';

--- a/src/lib/live2d/auto-intake.ts
+++ b/src/lib/live2d/auto-intake.ts
@@ -12,6 +12,13 @@ export interface ReferenceSheetGridOptions {
   imageHeight: number;
 }
 
+export interface Live2DAutoIntakeResult {
+  annotations: Live2DAnnotation[];
+  detectedParts: string[];
+  reviewRequired: true;
+  scopeNote: string;
+}
+
 export const LIVE2D_REFERENCE_SHEET_PARTS: readonly Live2DReferenceSheetPart[] = [
   { number: 1, part: 'head_base', label: '01 head base', hiddenArea: 'face under bangs and jaw overlap' },
   { number: 2, part: 'face_base', label: '02 face without hair/eyes/mouth', hiddenArea: 'face under bangs' },
@@ -59,6 +66,17 @@ function assertValidImageSize({ imageWidth, imageHeight }: ReferenceSheetGridOpt
   }
 }
 
+export function shouldAutoIntakeLive2D(prompt: string, live2dEnabled: boolean): boolean {
+  if (live2dEnabled) return true;
+  const normalized = prompt.toLowerCase();
+  return normalized.includes('live2d') && (
+    normalized.includes('part sheet')
+    || normalized.includes('reference sheet')
+    || normalized.includes('separated parts')
+    || normalized.includes('파츠')
+  );
+}
+
 export function proposeReferenceSheetGridAnnotations(options: ReferenceSheetGridOptions): Live2DAnnotation[] {
   assertValidImageSize(options);
 
@@ -87,4 +105,14 @@ export function proposeReferenceSheetGridAnnotations(options: ReferenceSheetGrid
       note: 'Deterministic Live2D reference-sheet candidate box. Review required before export or rigging.',
     } satisfies Live2DAnnotation;
   });
+}
+
+export function createLive2DAutoIntake(options: ReferenceSheetGridOptions): Live2DAutoIntakeResult {
+  const annotations = proposeReferenceSheetGridAnnotations(options);
+  return {
+    annotations,
+    detectedParts: annotations.map((annotation) => annotation.part).filter((part): part is string => Boolean(part)),
+    reviewRequired: true,
+    scopeNote: 'Auto-intake creates candidate Live2D part boxes only. Review is required; this does not create a rigged Cubism model or .moc3.',
+  };
 }

--- a/src/lib/live2d/auto-intake.ts
+++ b/src/lib/live2d/auto-intake.ts
@@ -1,0 +1,90 @@
+import type { Live2DAnnotation } from './contract';
+
+export interface Live2DReferenceSheetPart {
+  number: number;
+  part: string;
+  label: string;
+  hiddenArea?: string;
+}
+
+export interface ReferenceSheetGridOptions {
+  imageWidth: number;
+  imageHeight: number;
+}
+
+export const LIVE2D_REFERENCE_SHEET_PARTS: readonly Live2DReferenceSheetPart[] = [
+  { number: 1, part: 'head_base', label: '01 head base', hiddenArea: 'face under bangs and jaw overlap' },
+  { number: 2, part: 'face_base', label: '02 face without hair/eyes/mouth', hiddenArea: 'face under bangs' },
+  { number: 3, part: 'neck', label: '03 neck', hiddenArea: 'neck under head and collar' },
+  { number: 4, part: 'body_base', label: '04 body base', hiddenArea: 'torso under outfit and arms' },
+  { number: 5, part: 'outfit_torso', label: '05 outfit torso', hiddenArea: 'torso under arms' },
+  { number: 6, part: 'left_upper_arm', label: '06 left upper arm', hiddenArea: 'shoulder overlap under torso/hair' },
+  { number: 7, part: 'left_forearm', label: '07 left forearm', hiddenArea: 'elbow overlap' },
+  { number: 8, part: 'left_hand', label: '08 left hand', hiddenArea: 'wrist overlap' },
+  { number: 9, part: 'right_upper_arm', label: '09 right upper arm', hiddenArea: 'shoulder overlap under torso/hair' },
+  { number: 10, part: 'right_forearm', label: '10 right forearm', hiddenArea: 'elbow overlap' },
+  { number: 11, part: 'right_hand', label: '11 right hand', hiddenArea: 'wrist overlap' },
+  { number: 12, part: 'front_hair', label: '12 front hair / bangs', hiddenArea: 'hair roots under overlapping locks' },
+  { number: 13, part: 'left_side_hair', label: '13 left side hair', hiddenArea: 'side hair under front hair' },
+  { number: 14, part: 'right_side_hair', label: '14 right side hair', hiddenArea: 'side hair under front hair' },
+  { number: 15, part: 'back_hair', label: '15 back hair', hiddenArea: 'back hair behind head and neck' },
+  { number: 16, part: 'left_eye_white', label: '16 left eye white', hiddenArea: 'eye area under eyelids' },
+  { number: 17, part: 'right_eye_white', label: '17 right eye white', hiddenArea: 'eye area under eyelids' },
+  { number: 18, part: 'left_iris', label: '18 left iris', hiddenArea: 'iris under eyelids' },
+  { number: 19, part: 'right_iris', label: '19 right iris', hiddenArea: 'iris under eyelids' },
+  { number: 20, part: 'left_upper_eyelid', label: '20 left upper eyelid' },
+  { number: 21, part: 'right_upper_eyelid', label: '21 right upper eyelid' },
+  { number: 22, part: 'left_eyebrow', label: '22 left eyebrow', hiddenArea: 'brow area under bangs' },
+  { number: 23, part: 'right_eyebrow', label: '23 right eyebrow', hiddenArea: 'brow area under bangs' },
+  { number: 24, part: 'closed_mouth', label: '24 closed mouth' },
+  { number: 25, part: 'open_mouth_interior', label: '25 open mouth interior', hiddenArea: 'inside mouth cavity' },
+  { number: 26, part: 'mouth_teeth_tongue', label: '26 teeth and tongue', hiddenArea: 'inside mouth cavity' },
+] as const;
+
+const GRID_COLUMNS = 4;
+const GRID_ROWS = 7;
+const RIGHT_GRID_X = 0.5;
+const GRID_OUTER_MARGIN_X = 0.035;
+const GRID_OUTER_MARGIN_Y = 0.055;
+const GRID_GAP_X = 0.018;
+const GRID_GAP_Y = 0.018;
+
+function roundNormalized(value: number): number {
+  return Number(value.toFixed(6));
+}
+
+function assertValidImageSize({ imageWidth, imageHeight }: ReferenceSheetGridOptions): void {
+  if (!Number.isFinite(imageWidth) || !Number.isFinite(imageHeight) || imageWidth <= 0 || imageHeight <= 0) {
+    throw new Error('Live2D auto-intake requires positive finite imageWidth and imageHeight');
+  }
+}
+
+export function proposeReferenceSheetGridAnnotations(options: ReferenceSheetGridOptions): Live2DAnnotation[] {
+  assertValidImageSize(options);
+
+  const gridX = RIGHT_GRID_X + GRID_OUTER_MARGIN_X;
+  const gridY = GRID_OUTER_MARGIN_Y;
+  const gridWidth = 1 - RIGHT_GRID_X - (GRID_OUTER_MARGIN_X * 2);
+  const gridHeight = 1 - (GRID_OUTER_MARGIN_Y * 2);
+  const cellWidth = (gridWidth - (GRID_GAP_X * (GRID_COLUMNS - 1))) / GRID_COLUMNS;
+  const cellHeight = (gridHeight - (GRID_GAP_Y * (GRID_ROWS - 1))) / GRID_ROWS;
+
+  return LIVE2D_REFERENCE_SHEET_PARTS.map((part, index) => {
+    const row = Math.floor(index / GRID_COLUMNS);
+    const column = index % GRID_COLUMNS;
+    return {
+      id: `live2d-part-${String(part.number).padStart(2, '0')}`,
+      kind: 'bbox',
+      label: part.label,
+      part: part.part,
+      hiddenArea: part.hiddenArea,
+      bbox: {
+        x: roundNormalized(gridX + (column * (cellWidth + GRID_GAP_X))),
+        y: roundNormalized(gridY + (row * (cellHeight + GRID_GAP_Y))),
+        width: roundNormalized(cellWidth),
+        height: roundNormalized(cellHeight),
+      },
+      note: 'Deterministic Live2D reference-sheet candidate box. Review required before export or rigging.',
+    } satisfies Live2DAnnotation;
+  });
+}

--- a/src/lib/live2d/contract.ts
+++ b/src/lib/live2d/contract.ts
@@ -1,0 +1,109 @@
+import type { BoundingBox, Provider } from '@/types';
+import type { ProjectHistoryEntry, ProjectSettings } from '@/lib/projects/schema';
+
+export const LIVE2D_MANIFEST_SCHEMA_VERSION = 1;
+
+export const LIVE2D_PROMPT_PRESET = `Create a Live2D-ready upper-body anime character part sheet.
+Use a clean front-facing neutral pose and one full preview of the final character.
+Separate these transparent-friendly parts with visible spacing: head base, face without hair/eyes/mouth, neck, body base, outfit torso, left arm, right arm, front hair, side hair, back hair, eye whites, irises, eyelids, eyebrows, closed mouth, and open mouth interior.
+Draw hidden areas that would be covered in the final character, including face under bangs, torso under arms, neck under head, eye areas under eyelids, and mouth interior.
+Do not claim automatic rigging or .moc3 generation.`;
+
+export type Live2DAnnotationKind = 'bbox' | 'memo' | 'path';
+
+export interface Live2DNormalizedBBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface Live2DAnnotation {
+  id: string;
+  kind: Live2DAnnotationKind;
+  label: string;
+  part?: string;
+  hiddenArea?: string;
+  bbox?: Live2DNormalizedBBox;
+  note?: string;
+}
+
+export interface Live2DHiddenAreaNote {
+  part: string;
+  note: string;
+}
+
+export interface Live2DSelectedAsset {
+  historyEntryId: string;
+  assetPath: string;
+  provider: Provider;
+}
+
+export interface Live2DManifest {
+  schemaVersion: typeof LIVE2D_MANIFEST_SCHEMA_VERSION;
+  selected: Live2DSelectedAsset;
+  annotations: Live2DAnnotation[];
+  hiddenAreaNotes: Live2DHiddenAreaNote[];
+}
+
+export interface Live2DProjectSettings {
+  enabled: boolean;
+  selectedHistoryEntryId?: string | null;
+}
+
+export function createEmptyLive2DProjectSettings(): Live2DProjectSettings {
+  return { enabled: false, selectedHistoryEntryId: null };
+}
+
+export function normalizeLive2DProjectSettings(value: unknown): Live2DProjectSettings {
+  if (!value || typeof value !== 'object') return createEmptyLive2DProjectSettings();
+  const record = value as Record<string, unknown>;
+  return {
+    enabled: record.enabled === true,
+    selectedHistoryEntryId: typeof record.selectedHistoryEntryId === 'string' ? record.selectedHistoryEntryId : null,
+  };
+}
+
+export function buildLive2DSystemPrompt(existingSystemPrompt = ''): string {
+  const trimmed = existingSystemPrompt.trim();
+  if (!trimmed) return LIVE2D_PROMPT_PRESET;
+  if (trimmed.includes(LIVE2D_PROMPT_PRESET)) return trimmed;
+  return `${trimmed}\n\n${LIVE2D_PROMPT_PRESET}`;
+}
+
+export function bboxToLive2DAnnotation(box: BoundingBox, index: number): Live2DAnnotation {
+  return {
+    id: box.id,
+    kind: 'bbox',
+    label: `Live2D annotation ${index + 1}`,
+    bbox: {
+      x: box.x,
+      y: box.y,
+      width: box.width,
+      height: box.height,
+    },
+  };
+}
+
+export function buildLive2DManifest(options: {
+  selectedEntry: ProjectHistoryEntry;
+  annotations?: Live2DAnnotation[];
+  hiddenAreaNotes?: Live2DHiddenAreaNote[];
+}): Live2DManifest {
+  return {
+    schemaVersion: LIVE2D_MANIFEST_SCHEMA_VERSION,
+    selected: {
+      historyEntryId: options.selectedEntry.id,
+      assetPath: options.selectedEntry.assetPath,
+      provider: options.selectedEntry.provider,
+    },
+    annotations: options.annotations ?? [],
+    hiddenAreaNotes: options.hiddenAreaNotes ?? [],
+  };
+}
+
+export function getSelectedLive2DHistoryEntry(settings: ProjectSettings, entries: ProjectHistoryEntry[]): ProjectHistoryEntry | null {
+  const selectedId = settings.live2d.selectedHistoryEntryId;
+  if (selectedId) return entries.find((entry) => entry.id === selectedId) ?? null;
+  return entries[0] ?? null;
+}

--- a/src/lib/projects/metadata-store.ts
+++ b/src/lib/projects/metadata-store.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, rename, open } from 'node:fs/promises';
 import path from 'node:path';
 import { nanoid } from 'nanoid';
 import type { Provider } from '@/types';
+import { createLive2DAutoIntake } from '@/lib/live2d/auto-intake';
 import { buildLive2DManifest, buildLive2DSystemPrompt, type Live2DManifest } from '@/lib/live2d/contract';
 import { createEmptyHistory, createEmptyProjectSettings, HISTORY_SCHEMA_VERSION, isProjectHistory, normalizeProjectSettings, PROJECT_SCHEMA_VERSION, type ProjectHistory, type ProjectHistoryEntry, type ProjectManifest, type ProjectReferenceImage, type ProjectResultType, type ProjectSettings, type ProjectSettingsPatch } from './schema';
 import { ensureProjectDirectories, getHistoryPath, getLive2DManifestPath, getManifestPath } from './paths';
@@ -131,18 +132,26 @@ export async function enableLive2DMode(projectRoot: string): Promise<ProjectSett
   return normalizeProjectSettings(manifest.settings);
 }
 
+async function selectLive2DHistoryEntry(
+  projectRoot: string,
+  selectedHistoryEntryId: string | null | undefined,
+): Promise<{ manifest: ProjectManifest; settings: ProjectSettings; selectedEntry: ProjectHistoryEntry }> {
+  const [manifest, history] = await Promise.all([
+    readProjectManifest(projectRoot),
+    readProjectHistory(projectRoot),
+  ]);
+  const settings = normalizeProjectSettings(manifest.settings);
+  const selectedId = selectedHistoryEntryId ?? settings.live2d.selectedHistoryEntryId ?? history.entries[0]?.id;
+  const selectedEntry = history.entries.find((entry) => entry.id === selectedId);
+  if (!selectedEntry) {
+    throw new Error('No selected BananaTape history entry is available for Live2D export');
+  }
+  return { manifest, settings, selectedEntry };
+}
+
 export async function writeLive2DManifest(projectRoot: string, selectedHistoryEntryId?: string | null): Promise<Live2DManifest> {
   return withProjectLock(projectRoot, async () => {
-    const [manifest, history] = await Promise.all([
-      readProjectManifest(projectRoot),
-      readProjectHistory(projectRoot),
-    ]);
-    const settings = normalizeProjectSettings(manifest.settings);
-    const selectedId = selectedHistoryEntryId ?? settings.live2d.selectedHistoryEntryId ?? history.entries[0]?.id;
-    const selectedEntry = history.entries.find((entry) => entry.id === selectedId);
-    if (!selectedEntry) {
-      throw new Error('No selected BananaTape history entry is available for Live2D export');
-    }
+    const { manifest, settings, selectedEntry } = await selectLive2DHistoryEntry(projectRoot, selectedHistoryEntryId);
     const live2dManifest = buildLive2DManifest({ selectedEntry });
     await atomicWriteJson(getLive2DManifestPath(projectRoot), live2dManifest);
     await atomicWriteJson(getManifestPath(projectRoot), {
@@ -157,6 +166,46 @@ export async function writeLive2DManifest(projectRoot: string, selectedHistoryEn
       updatedAt: new Date().toISOString(),
     });
     return live2dManifest;
+  });
+}
+
+export async function writeLive2DAutoIntakeManifest(
+  projectRoot: string,
+  options: {
+    selectedHistoryEntryId?: string | null;
+    imageWidth: number;
+    imageHeight: number;
+  },
+): Promise<{ manifest: Live2DManifest; annotationCount: number; detectedParts: string[]; reviewRequired: true; scopeNote: string }> {
+  return withProjectLock(projectRoot, async () => {
+    const { manifest, settings, selectedEntry } = await selectLive2DHistoryEntry(projectRoot, options.selectedHistoryEntryId);
+    const intake = createLive2DAutoIntake({ imageWidth: options.imageWidth, imageHeight: options.imageHeight });
+    const live2dManifest = buildLive2DManifest({
+      selectedEntry,
+      annotations: intake.annotations,
+      hiddenAreaNotes: intake.annotations
+        .filter((annotation) => annotation.part && annotation.hiddenArea)
+        .map((annotation) => ({ part: annotation.part as string, note: annotation.hiddenArea as string })),
+    });
+    await atomicWriteJson(getLive2DManifestPath(projectRoot), live2dManifest);
+    await atomicWriteJson(getManifestPath(projectRoot), {
+      ...manifest,
+      settings: {
+        ...settings,
+        live2d: {
+          enabled: true,
+          selectedHistoryEntryId: selectedEntry.id,
+        },
+      },
+      updatedAt: new Date().toISOString(),
+    });
+    return {
+      manifest: live2dManifest,
+      annotationCount: intake.annotations.length,
+      detectedParts: intake.detectedParts,
+      reviewRequired: intake.reviewRequired,
+      scopeNote: intake.scopeNote,
+    };
   });
 }
 

--- a/src/lib/projects/metadata-store.ts
+++ b/src/lib/projects/metadata-store.ts
@@ -2,8 +2,9 @@ import { mkdir, readFile, rename, open } from 'node:fs/promises';
 import path from 'node:path';
 import { nanoid } from 'nanoid';
 import type { Provider } from '@/types';
+import { buildLive2DManifest, buildLive2DSystemPrompt, type Live2DManifest } from '@/lib/live2d/contract';
 import { createEmptyHistory, createEmptyProjectSettings, HISTORY_SCHEMA_VERSION, isProjectHistory, normalizeProjectSettings, PROJECT_SCHEMA_VERSION, type ProjectHistory, type ProjectHistoryEntry, type ProjectManifest, type ProjectReferenceImage, type ProjectResultType, type ProjectSettings, type ProjectSettingsPatch } from './schema';
-import { ensureProjectDirectories, getHistoryPath, getManifestPath } from './paths';
+import { ensureProjectDirectories, getHistoryPath, getLive2DManifestPath, getManifestPath } from './paths';
 import { withProjectLock } from './locks';
 import { sanitizeProjectName, slugifyProjectName } from './validate';
 
@@ -109,6 +110,53 @@ export async function clearProjectDesignContext(projectRoot: string): Promise<Pr
   return updateProjectSettings(projectRoot, {
     designContext: '',
     designContextFileName: '',
+  });
+}
+
+export async function enableLive2DMode(projectRoot: string): Promise<ProjectSettings> {
+  const manifest = await updateProjectManifest(projectRoot, (current) => {
+    const settings = normalizeProjectSettings(current.settings);
+    return {
+      ...current,
+      settings: {
+        ...settings,
+        systemPrompt: buildLive2DSystemPrompt(settings.systemPrompt),
+        live2d: {
+          ...settings.live2d,
+          enabled: true,
+        },
+      },
+    };
+  });
+  return normalizeProjectSettings(manifest.settings);
+}
+
+export async function writeLive2DManifest(projectRoot: string, selectedHistoryEntryId?: string | null): Promise<Live2DManifest> {
+  return withProjectLock(projectRoot, async () => {
+    const [manifest, history] = await Promise.all([
+      readProjectManifest(projectRoot),
+      readProjectHistory(projectRoot),
+    ]);
+    const settings = normalizeProjectSettings(manifest.settings);
+    const selectedId = selectedHistoryEntryId ?? settings.live2d.selectedHistoryEntryId ?? history.entries[0]?.id;
+    const selectedEntry = history.entries.find((entry) => entry.id === selectedId);
+    if (!selectedEntry) {
+      throw new Error('No selected BananaTape history entry is available for Live2D export');
+    }
+    const live2dManifest = buildLive2DManifest({ selectedEntry });
+    await atomicWriteJson(getLive2DManifestPath(projectRoot), live2dManifest);
+    await atomicWriteJson(getManifestPath(projectRoot), {
+      ...manifest,
+      settings: {
+        ...settings,
+        live2d: {
+          enabled: true,
+          selectedHistoryEntryId: selectedEntry.id,
+        },
+      },
+      updatedAt: new Date().toISOString(),
+    });
+    return live2dManifest;
   });
 }
 

--- a/src/lib/projects/paths.ts
+++ b/src/lib/projects/paths.ts
@@ -34,6 +34,10 @@ export function getHistoryPath(projectRoot: string): string {
   return path.join(projectRoot, 'history.json');
 }
 
+export function getLive2DManifestPath(projectRoot: string): string {
+  return path.join(projectRoot, 'live2d', 'manifest.json');
+}
+
 export async function ensureProjectDirectories(projectRoot: string): Promise<void> {
   await mkdir(path.join(projectRoot, 'assets'), { recursive: true });
   await mkdir(path.join(projectRoot, 'references'), { recursive: true });

--- a/src/lib/projects/schema.ts
+++ b/src/lib/projects/schema.ts
@@ -1,4 +1,5 @@
 import type { Provider } from '@/types';
+import { createEmptyLive2DProjectSettings, normalizeLive2DProjectSettings, type Live2DProjectSettings } from '@/lib/live2d/contract';
 
 export const PROJECT_SCHEMA_VERSION = 1;
 export const HISTORY_SCHEMA_VERSION = 1;
@@ -26,6 +27,7 @@ export interface ProjectReferenceImage {
 export interface ProjectSettings {
   systemPrompt: string;
   referenceImages: ProjectReferenceImage[];
+  live2d: Live2DProjectSettings;
   // Locked markdown loaded from DESIGN.md upload. Replaced only via the
   // /api/projects/design-context endpoint; never written through PUT settings.
   // Optional so legacy project.json files round-trip unchanged.
@@ -36,7 +38,7 @@ export interface ProjectSettings {
 // Narrow on purpose: do not widen to Partial<ProjectSettings> or callers can
 // silently overwrite referenceImages or future read-only fields.
 export type ProjectSettingsPatch = Partial<
-  Pick<ProjectSettings, 'systemPrompt' | 'designContext' | 'designContextFileName'>
+  Pick<ProjectSettings, 'systemPrompt' | 'designContext' | 'designContextFileName' | 'live2d'>
 >;
 
 export interface ProjectHistoryEntry {
@@ -64,14 +66,15 @@ export interface PersistedImageResult {
 }
 
 export function createEmptyProjectSettings(): ProjectSettings {
-  return { systemPrompt: '', referenceImages: [] };
+  return { systemPrompt: '', referenceImages: [], live2d: createEmptyLive2DProjectSettings() };
 }
 
-export function normalizeProjectSettings(settings: ProjectManifest['settings']): ProjectSettings {
+export function normalizeProjectSettings(settings: Partial<ProjectSettings> | undefined): ProjectSettings {
   const normalized: ProjectSettings = {
     ...createEmptyProjectSettings(),
     ...(settings ?? {}),
     referenceImages: Array.isArray(settings?.referenceImages) ? settings.referenceImages : [],
+    live2d: normalizeLive2DProjectSettings(settings?.live2d),
   };
 
   if (typeof normalized.designContext !== 'string' || normalized.designContext.length === 0) {

--- a/tests/unit/design-context.test.ts
+++ b/tests/unit/design-context.test.ts
@@ -21,7 +21,7 @@ async function tempProjectRoot() {
 describe('design context schema', () => {
   it('omits designContext fields from empty settings so legacy project.json still round-trips', () => {
     const empty = createEmptyProjectSettings();
-    expect(empty).toEqual({ systemPrompt: '', referenceImages: [] });
+    expect(empty).toEqual({ systemPrompt: '', referenceImages: [], live2d: { enabled: false, selectedHistoryEntryId: null } });
     expect('designContext' in empty).toBe(false);
     expect('designContextFileName' in empty).toBe(false);
   });
@@ -33,7 +33,7 @@ describe('design context schema', () => {
       designContext: '',
       designContextFileName: '',
     });
-    expect(normalized).toEqual({ systemPrompt: '', referenceImages: [] });
+    expect(normalized).toEqual({ systemPrompt: '', referenceImages: [], live2d: { enabled: false, selectedHistoryEntryId: null } });
   });
 
   it('preserves non-empty designContext fields during normalization', () => {
@@ -46,6 +46,7 @@ describe('design context schema', () => {
     expect(normalized).toEqual({
       systemPrompt: '',
       referenceImages: [],
+      live2d: { enabled: false, selectedHistoryEntryId: null },
       designContext: '# Title\n- one',
       designContextFileName: 'DESIGN.md',
     });

--- a/tests/unit/live2d-auto-intake.test.ts
+++ b/tests/unit/live2d-auto-intake.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { LIVE2D_REFERENCE_SHEET_PARTS, proposeReferenceSheetGridAnnotations } from '@/lib/live2d/auto-intake';
+import { createLive2DAutoIntake, LIVE2D_REFERENCE_SHEET_PARTS, proposeReferenceSheetGridAnnotations, shouldAutoIntakeLive2D } from '@/lib/live2d/auto-intake';
 
 describe('Live2D reference sheet auto-intake', () => {
   it('exposes the stable 26-part reference-sheet taxonomy', () => {
@@ -63,6 +63,21 @@ describe('Live2D reference sheet auto-intake', () => {
     });
     expect(annotations.every((annotation) => annotation.bbox && annotation.bbox.x >= 0.5 && annotation.bbox.x + annotation.bbox.width <= 1)).toBe(true);
     expect(annotations.every((annotation) => annotation.note?.includes('Review required'))).toBe(true);
+  });
+
+  it('wraps proposals in a review-required auto-intake result', () => {
+    const result = createLive2DAutoIntake({ imageWidth: 1536, imageHeight: 1024 });
+
+    expect(result.reviewRequired).toBe(true);
+    expect(result.annotations).toHaveLength(26);
+    expect(result.detectedParts).toContain('front_hair');
+    expect(result.scopeNote).toContain('does not create a rigged Cubism model');
+  });
+
+  it('detects Live2D-oriented prompts without requiring a separate user action', () => {
+    expect(shouldAutoIntakeLive2D('Create a Live2D reference sheet with separated parts', false)).toBe(true);
+    expect(shouldAutoIntakeLive2D('평범한 포스터 생성', false)).toBe(false);
+    expect(shouldAutoIntakeLive2D('anything', true)).toBe(true);
   });
 
   it('fails clearly for invalid image sizes instead of guessing', () => {

--- a/tests/unit/live2d-auto-intake.test.ts
+++ b/tests/unit/live2d-auto-intake.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { LIVE2D_REFERENCE_SHEET_PARTS, proposeReferenceSheetGridAnnotations } from '@/lib/live2d/auto-intake';
+
+describe('Live2D reference sheet auto-intake', () => {
+  it('exposes the stable 26-part reference-sheet taxonomy', () => {
+    expect(LIVE2D_REFERENCE_SHEET_PARTS).toHaveLength(26);
+    expect(LIVE2D_REFERENCE_SHEET_PARTS.map((part) => part.number)).toEqual(Array.from({ length: 26 }, (_, index) => index + 1));
+    expect(LIVE2D_REFERENCE_SHEET_PARTS.map((part) => part.part)).toEqual([
+      'head_base',
+      'face_base',
+      'neck',
+      'body_base',
+      'outfit_torso',
+      'left_upper_arm',
+      'left_forearm',
+      'left_hand',
+      'right_upper_arm',
+      'right_forearm',
+      'right_hand',
+      'front_hair',
+      'left_side_hair',
+      'right_side_hair',
+      'back_hair',
+      'left_eye_white',
+      'right_eye_white',
+      'left_iris',
+      'right_iris',
+      'left_upper_eyelid',
+      'right_upper_eyelid',
+      'left_eyebrow',
+      'right_eyebrow',
+      'closed_mouth',
+      'open_mouth_interior',
+      'mouth_teeth_tongue',
+    ]);
+  });
+
+  it('proposes 26 deterministic normalized bbox annotations for a 1536x1024 strict grid sheet', () => {
+    const annotations = proposeReferenceSheetGridAnnotations({ imageWidth: 1536, imageHeight: 1024 });
+
+    expect(annotations).toHaveLength(26);
+    expect(annotations[0]).toMatchObject({
+      id: 'live2d-part-01',
+      kind: 'bbox',
+      label: '01 head base',
+      part: 'head_base',
+      bbox: { x: 0.535, y: 0.055, width: 0.094, height: 0.111714 },
+    });
+    expect(annotations[1]).toMatchObject({
+      id: 'live2d-part-02',
+      part: 'face_base',
+      bbox: { x: 0.647, y: 0.055, width: 0.094, height: 0.111714 },
+    });
+    expect(annotations[4]).toMatchObject({
+      id: 'live2d-part-05',
+      part: 'outfit_torso',
+      bbox: { x: 0.535, y: 0.184714, width: 0.094, height: 0.111714 },
+    });
+    expect(annotations[25]).toMatchObject({
+      id: 'live2d-part-26',
+      part: 'mouth_teeth_tongue',
+      bbox: { x: 0.647, y: 0.833286, width: 0.094, height: 0.111714 },
+    });
+    expect(annotations.every((annotation) => annotation.bbox && annotation.bbox.x >= 0.5 && annotation.bbox.x + annotation.bbox.width <= 1)).toBe(true);
+    expect(annotations.every((annotation) => annotation.note?.includes('Review required'))).toBe(true);
+  });
+
+  it('fails clearly for invalid image sizes instead of guessing', () => {
+    expect(() => proposeReferenceSheetGridAnnotations({ imageWidth: 0, imageHeight: 1024 })).toThrow('positive finite imageWidth and imageHeight');
+    expect(() => proposeReferenceSheetGridAnnotations({ imageWidth: 1536, imageHeight: Number.NaN })).toThrow('positive finite imageWidth and imageHeight');
+  });
+});

--- a/tests/unit/projects.test.ts
+++ b/tests/unit/projects.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { dataUrlToBuffer, persistImageResult, readAsset } from '@/lib/projects/asset-store';
-import { appendProjectReference, createProject, enableLive2DMode, readProjectHistory, readProjectManifest, readProjectSettings, removeProjectReference, updateProjectSettings, writeLive2DManifest } from '@/lib/projects/metadata-store';
+import { appendProjectReference, createProject, enableLive2DMode, readProjectHistory, readProjectManifest, readProjectSettings, removeProjectReference, updateProjectSettings, writeLive2DAutoIntakeManifest, writeLive2DManifest } from '@/lib/projects/metadata-store';
 import { assertProjectRelativePath, resolveInsideProject } from '@/lib/projects/paths';
 import { assertValidAssetId, assertValidProjectId, slugifyProjectName } from '@/lib/projects/validate';
 
@@ -111,6 +111,39 @@ describe('project metadata and asset persistence', () => {
     });
 
     const manifestFile = JSON.parse(await readFile(path.join(projectRoot, 'live2d', 'manifest.json'), 'utf8'));
+    expect(manifestFile.selected.historyEntryId).toBe(persisted.historyEntry.id);
+    await expect(readProjectSettings(projectRoot)).resolves.toMatchObject({
+      live2d: { enabled: true, selectedHistoryEntryId: persisted.historyEntry.id },
+    });
+  });
+
+  it('writes Live2D auto-intake candidate annotations for the selected generated sheet', async () => {
+    const projectRoot = await tempProjectRoot();
+    await createProject(projectRoot, 'Live2D Auto Intake Test');
+
+    const persisted = await persistImageResult({
+      projectRoot,
+      imageDataUrl: PNG_1X1,
+      prompt: 'Live2D reference sheet with separated parts',
+      provider: 'god-tibo',
+      type: 'generate',
+    });
+
+    const result = await writeLive2DAutoIntakeManifest(projectRoot, {
+      selectedHistoryEntryId: persisted.historyEntry.id,
+      imageWidth: 1536,
+      imageHeight: 1024,
+    });
+
+    expect(result.reviewRequired).toBe(true);
+    expect(result.annotationCount).toBe(26);
+    expect(result.detectedParts).toContain('front_hair');
+    expect(result.manifest.annotations).toHaveLength(26);
+    expect(result.manifest.hiddenAreaNotes.length).toBeGreaterThan(0);
+    expect(result.scopeNote).toContain('does not create a rigged Cubism model');
+
+    const manifestFile = JSON.parse(await readFile(path.join(projectRoot, 'live2d', 'manifest.json'), 'utf8'));
+    expect(manifestFile.annotations).toHaveLength(26);
     expect(manifestFile.selected.historyEntryId).toBe(persisted.historyEntry.id);
     await expect(readProjectSettings(projectRoot)).resolves.toMatchObject({
       live2d: { enabled: true, selectedHistoryEntryId: persisted.historyEntry.id },

--- a/tests/unit/projects.test.ts
+++ b/tests/unit/projects.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { dataUrlToBuffer, persistImageResult, readAsset } from '@/lib/projects/asset-store';
-import { appendProjectReference, createProject, readProjectHistory, readProjectManifest, readProjectSettings, removeProjectReference, updateProjectSettings } from '@/lib/projects/metadata-store';
+import { appendProjectReference, createProject, enableLive2DMode, readProjectHistory, readProjectManifest, readProjectSettings, removeProjectReference, updateProjectSettings, writeLive2DManifest } from '@/lib/projects/metadata-store';
 import { assertProjectRelativePath, resolveInsideProject } from '@/lib/projects/paths';
 import { assertValidAssetId, assertValidProjectId, slugifyProjectName } from '@/lib/projects/validate';
 
@@ -50,7 +50,7 @@ describe('project metadata and asset persistence', () => {
     expect(manifest.id).toBe('launch-test');
     await expect(readProjectManifest(projectRoot)).resolves.toMatchObject({ id: 'launch-test', name: 'Launch Test' });
     await expect(readProjectHistory(projectRoot)).resolves.toMatchObject({ revision: 0, entries: [] });
-    await expect(readProjectSettings(projectRoot)).resolves.toEqual({ systemPrompt: '', referenceImages: [] });
+    await expect(readProjectSettings(projectRoot)).resolves.toEqual({ systemPrompt: '', referenceImages: [], live2d: { enabled: false, selectedHistoryEntryId: null } });
   });
 
   it('persists project-level system prompt and reference image metadata', async () => {
@@ -80,6 +80,43 @@ describe('project metadata and asset persistence', () => {
       referenceImages: [],
     });
   });
+
+
+  it('enables Live2D mode and writes a selected live2d manifest contract', async () => {
+    const projectRoot = await tempProjectRoot();
+    await createProject(projectRoot, 'Live2D Test');
+
+    const persisted = await persistImageResult({
+      projectRoot,
+      imageDataUrl: PNG_1X1,
+      prompt: 'Live2D part sheet',
+      provider: 'god-tibo',
+      type: 'generate',
+    });
+
+    const settings = await enableLive2DMode(projectRoot);
+    expect(settings.live2d.enabled).toBe(true);
+    expect(settings.systemPrompt).toContain('Live2D-ready upper-body anime character part sheet');
+
+    const live2dManifest = await writeLive2DManifest(projectRoot, persisted.historyEntry.id);
+    expect(live2dManifest).toMatchObject({
+      schemaVersion: 1,
+      selected: {
+        historyEntryId: persisted.historyEntry.id,
+        assetPath: persisted.historyEntry.assetPath,
+        provider: 'god-tibo',
+      },
+      annotations: [],
+      hiddenAreaNotes: [],
+    });
+
+    const manifestFile = JSON.parse(await readFile(path.join(projectRoot, 'live2d', 'manifest.json'), 'utf8'));
+    expect(manifestFile.selected.historyEntryId).toBe(persisted.historyEntry.id);
+    await expect(readProjectSettings(projectRoot)).resolves.toMatchObject({
+      live2d: { enabled: true, selectedHistoryEntryId: persisted.historyEntry.id },
+    });
+  });
+
 
   it('decodes data URLs and persists assets plus history metadata without embedding image data', async () => {
     const projectRoot = await tempProjectRoot();


### PR DESCRIPTION
## Summary
- Adds a committed implementation plan for BananaTape's missing Live2D post-generation auto-intake flow.
- Adds deterministic Live2D reference-sheet auto-intake that proposes 26 review-required candidate part boxes for the strict grid layout.
- Adds an auto-intake API route plus generation-route integration so Live2D-oriented generations can immediately persist `live2d/manifest.json` instead of stopping at an image-only canvas state.
- Surfaces explicit review-required status copy; this does not claim Cubism rigging, `.moc3`, or general image segmentation.

## Problem
BananaTape could generate a Live2D-style part/reference sheet, but the workflow stopped there. The user still had to manually advance into bbox labeling and handoff creation, so the product did not behave like an end-to-end Live2D intake surface.

## Root cause
The previous Live2D handoff work provided a manifest contract and manual writer, but there was no post-generation orchestration hook or deterministic intake draft step.

## What changed
- `docs/live2d-auto-intake-pr-plan.md`: plan artifact used before OMX implementation.
- `src/lib/live2d/auto-intake.ts`: 26-part taxonomy, deterministic grid bbox proposal, prompt trigger helper, and review-required auto-intake result.
- `src/app/api/projects/live2d/auto-intake/route.ts`: explicit auto-intake endpoint for the active project.
- `src/app/api/generate/route.ts`: runs Live2D auto-intake after successful generation when Live2D mode or prompt intent matches.
- `src/components/Composer/PromptComposerProvider.tsx`: shows auto-intake status copy after generation.
- `src/lib/projects/metadata-store.ts`: persists auto-intake manifests and Live2D selected asset settings.
- Unit tests cover taxonomy/mapping, prompt detection, and persisted candidate manifests.

## Why this design
The current generated sheet format is a strict grid reference sheet, so the first useful MVP is a deterministic layout-contract detector. That creates an immediate product bridge without adding heavyweight SAM/OCR/VLM dependencies or pretending arbitrary images can be segmented.

## Overlap assessment
Net-new. Existing PRs in this repo covered design context and standalone asset sync; no existing PR delivers Live2D post-generation auto-intake.

## Validation
- `npx vitest run tests/unit/live2d-auto-intake.test.ts tests/unit/projects.test.ts` → 14 passed
- `npm run typecheck` → passed
- `git diff --stat origin/main...HEAD` inspected

## Risks / compatibility
- The detector is intentionally layout-contract-based, not a general segmentation model.
- Candidate boxes require review before export or rigging.
- Future work should add real box edge detection, OCR/VLM label confidence, crop/background cleanup, and Cubism-side automation without removing the review-required semantics.

## Diff classification
Net-new behavior change.
