### PR TITLE
Add Magic Layer element editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,18 @@ If the auth file is missing or expired, the `codex` provider will fail until Cod
 
 ### Magic Layer segmentation (SAM3 on macOS)
 
-Magic Layer calls a local SAM3-compatible segmentation command when `BANANATAPE_SAM3_COMMAND` is set. The command should accept an input image path and output a JSON file containing `segments`, each with a `bbox` and optional `maskDataUrl` PNG data URL. Use `{input}` and `{output}` placeholders when your wrapper needs flags:
+Magic Layer calls a local SAM3-compatible segmentation command when `BANANATAPE_SAM3_COMMAND` is set. BananaTape includes a wrapper at `scripts/sam3-magic-layer.py` that adapts Meta's official `facebookresearch/sam3` Python API to the JSON contract used by the editor.
+
+> Note: the official SAM 3 setup currently expects a separate Python/SAM 3 environment. Install and validate SAM 3 outside BananaTape first; the npm package does not bundle model weights or Python dependencies.
+
+Example wrapper setup after SAM 3 works locally:
 
 ```bash
-export BANANATAPE_SAM3_COMMAND="python3 /path/to/sam3_segment.py --input {input} --output {output}"
+export BANANATAPE_SAM3_COMMAND="python3 /path/to/bananatape/scripts/sam3-magic-layer.py --prompts text,logo,person,product,object --input {input} --output {output}"
 bananatape launch logo-explorations
 ```
 
-Expected output shape:
+The command may also be any custom script that accepts an input image path and writes a JSON file containing `segments`, each with a `bbox` and optional full-image `maskDataUrl` PNG data URL:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It is meant for quick iteration: generate an image, annotate what should change,
 ## What the editor gives you
 
 - **Canvas annotations.** Draw boxes, arrows, pen marks, and sticky notes over the image before editing.
+- **Magic Layer.** Segment a generated or edited image into movable cutout layers so foreground elements and text-like regions can be dragged away or hidden.
 - **Project context.** Keep a system prompt and reference images attached to the project.
 - **Version history.** Save each generation or edit in the sidebar and reopen earlier results.
 - **Local project folders.** Store project metadata, references, and generated assets on disk.
@@ -46,7 +47,8 @@ Basic loop:
 3. Type a prompt and generate an image.
 4. Mark up the image with boxes, arrows, pen strokes, or sticky notes.
 5. Run an edit.
-6. Use the history sidebar to return to earlier results.
+6. For direct layout tweaks, click **Magic Layer**, select a detected element, then drag it or press Backspace to hide it.
+7. Use the history sidebar to return to earlier results.
 
 Useful commands:
 
@@ -88,6 +90,27 @@ bananatape launch logo-explorations
 ```
 
 If the auth file is missing or expired, the `codex` provider will fail until Codex CLI is signed in again.
+
+### Magic Layer segmentation (SAM3 on macOS)
+
+Magic Layer calls a local SAM3-compatible segmentation command when `BANANATAPE_SAM3_COMMAND` is set. The command should accept an input image path and output a JSON file containing `segments`, each with a `bbox` and optional `maskDataUrl` PNG data URL. Use `{input}` and `{output}` placeholders when your wrapper needs flags:
+
+```bash
+export BANANATAPE_SAM3_COMMAND="python3 /path/to/sam3_segment.py --input {input} --output {output}"
+bananatape launch logo-explorations
+```
+
+Expected output shape:
+
+```json
+{
+  "segments": [
+    { "id": "text-1", "label": "Text", "bbox": { "x": 120, "y": 80, "width": 320, "height": 90 }, "maskDataUrl": "data:image/png;base64,..." }
+  ]
+}
+```
+
+If the command is not configured, BananaTape uses a lightweight local fallback segmentation so the Magic Layer UI remains testable without downloading a model.
 
 ## Quick start for AI agents
 
@@ -140,6 +163,7 @@ Agent notes:
 ## What BananaTape does
 
 - Generate a new image from a prompt.
+- Segment a result with Magic Layer, then move or hide detected elements such as text regions.
 - Edit an image by drawing directly on the canvas.
 - Add sticky memo notes, arrows, and boxes to explain changes visually.
 - Attach reference images from the file picker or clipboard paste.
@@ -232,6 +256,7 @@ Common variables:
 BANANATAPE_PROJECTS_DIR   # optional project root override
 BANANATAPE_HOME           # optional CLI runtime/registry directory override
 OPENAI_API_KEY            # required for OpenAI provider calls
+BANANATAPE_SAM3_COMMAND   # optional local SAM3 segmentation command for Magic Layer
 ```
 
 The CLI sets these automatically for launched app instances:

--- a/README.md
+++ b/README.md
@@ -91,20 +91,48 @@ bananatape launch logo-explorations
 
 If the auth file is missing or expired, the `codex` provider will fail until Codex CLI is signed in again.
 
-### Magic Layer segmentation (SAM3 on macOS)
+### Magic Layer segmentation
 
-Magic Layer calls a local SAM3-compatible segmentation command when `BANANATAPE_SAM3_COMMAND` is set. BananaTape includes a wrapper at `scripts/sam3-magic-layer.py` that adapts Meta's official `facebookresearch/sam3` Python API to the JSON contract used by the editor.
+Magic Layer turns a generated image into draggable cutouts. BananaTape picks the segmentation backend automatically by platform.
 
-> Note: the official SAM 3 setup currently expects a separate Python/SAM 3 environment. Install and validate SAM 3 outside BananaTape first; the npm package does not bundle model weights or Python dependencies.
+**macOS Apple Silicon (M1/M2/M3/M4) — zero-config auto-install**
 
-Example wrapper setup after SAM 3 works locally:
+On the first Magic Layer click, BananaTape:
+
+1. Detects `darwin` + `arm64`.
+2. Creates a managed Python 3.13 virtualenv under `~/.bananatape/mlx_sam3/.venv`.
+3. Installs the lean MLX runtime (`mlx`, `torch`, `torchvision`, `pillow`, `huggingface-hub`, ...).
+4. Installs [`Deekshith-Dade/mlx_sam3`](https://github.com/Deekshith-Dade/mlx_sam3) from source.
+5. Caches everything; subsequent runs skip the install path entirely.
+
+The button shows **"Preparing AI…"** during the one-time setup (~5–15 min depending on bandwidth, ~4 GB on disk). Until the install finishes, BananaTape falls back to lightweight segmentation so the UI stays usable.
+
+Prerequisite: install [`uv`](https://docs.astral.sh/uv/) once. If `uv` is not on `PATH`, BananaTape returns fallback cutouts and the API response contains a `setupHint` with the install command:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Opt out of auto-install (CI, tests, custom setups):
+
+```bash
+export BANANATAPE_DISABLE_AUTO_INSTALL=1
+```
+
+`CI=true` also disables auto-install automatically.
+
+**Linux / NVIDIA CUDA — official SAM 3**
+
+On non-Apple platforms, set `BANANATAPE_SAM3_COMMAND` to point at the official `scripts/sam3-magic-layer.py` wrapper after installing [`facebookresearch/sam3`](https://github.com/facebookresearch/sam3) in a separate environment:
 
 ```bash
 export BANANATAPE_SAM3_COMMAND="python3 /path/to/bananatape/scripts/sam3-magic-layer.py --prompts text,logo,person,product,object --input {input} --output {output}"
 bananatape launch logo-explorations
 ```
 
-The command may also be any custom script that accepts an input image path and writes a JSON file containing `segments`, each with a `bbox` and optional full-image `maskDataUrl` PNG data URL:
+**Custom backend**
+
+`BANANATAPE_SAM3_COMMAND` accepts any command that takes `--input <image>` `--output <json>` and writes:
 
 ```json
 {
@@ -114,7 +142,7 @@ The command may also be any custom script that accepts an input image path and w
 }
 ```
 
-If the command is not configured, BananaTape uses a lightweight local fallback segmentation so the Magic Layer UI remains testable without downloading a model.
+If neither auto-install nor an explicit command is available, BananaTape uses a lightweight local fallback so the Magic Layer UI remains testable.
 
 ## Quick start for AI agents
 
@@ -257,10 +285,12 @@ In this mode, BananaTape still works as an editor, but project persistence is on
 Common variables:
 
 ```bash
-BANANATAPE_PROJECTS_DIR   # optional project root override
-BANANATAPE_HOME           # optional CLI runtime/registry directory override
-OPENAI_API_KEY            # required for OpenAI provider calls
-BANANATAPE_SAM3_COMMAND   # optional local SAM3 segmentation command for Magic Layer
+BANANATAPE_PROJECTS_DIR        # optional project root override
+BANANATAPE_HOME                # optional CLI runtime/registry directory override
+OPENAI_API_KEY                 # required for OpenAI provider calls
+BANANATAPE_SAM3_COMMAND        # optional explicit SAM3-compatible command for Magic Layer
+BANANATAPE_DISABLE_AUTO_INSTALL # set to 1 to skip the macOS mlx_sam3 auto-install
+BANANATAPE_UV_PATH             # optional absolute path to a uv binary (default: PATH search)
 ```
 
 The CLI sets these automatically for launched app instances:

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
   "files": [
     "bin/",
     "src/",
+    "scripts/sam3-magic-layer.py",
+    "scripts/sam3-magic-layer-mlx.py",
     "public/",
     "next.config.ts",
     "postcss.config.mjs",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,5 +21,8 @@ export default defineConfig({
     command: 'npm run dev -- -p 4567',
     url: 'http://localhost:4567',
     reuseExistingServer: !process.env.CI,
+    env: {
+      BANANATAPE_DISABLE_AUTO_INSTALL: '1',
+    },
   },
 });

--- a/scripts/sam3-magic-layer-mlx.py
+++ b/scripts/sam3-magic-layer-mlx.py
@@ -38,12 +38,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output", dest="output_path", help="Output JSON path.")
     parser.add_argument(
         "--prompts",
-        default="text,logo,person,animal,plant,product,object,foreground,subject,frame,table",
-        help="Comma-separated SAM 3 concept prompts to try.",
+        default="person,animal,cat,dog,bird,plant,flower,tree,food,product,bottle,cup,chair,table,car,building,text,logo",
+        help="Comma-separated SAM 3 concept prompts to try. Specific nouns work much better than generic 'object'.",
     )
-    parser.add_argument("--score-threshold", type=float, default=0.35, help="Minimum SAM 3 score to keep.")
+    parser.add_argument("--score-threshold", type=float, default=0.25, help="Minimum SAM 3 score to keep after model inference.")
     parser.add_argument("--max-segments", type=int, default=24, help="Maximum number of segments to emit.")
-    parser.add_argument("--confidence-threshold", type=float, default=0.3, help="Sam3Processor confidence threshold.")
+    parser.add_argument("--confidence-threshold", type=float, default=0.2, help="Sam3Processor confidence threshold before post-filtering.")
+    parser.add_argument("--min-area-ratio", type=float, default=0.002, help="Drop masks smaller than this fraction of the image.")
+    parser.add_argument("--max-area-ratio", type=float, default=0.75, help="Drop masks larger than this fraction of the image.")
+    parser.add_argument("--nms-iou", type=float, default=0.72, help="Drop lower-scoring boxes with IoU above this value.")
     parser.add_argument("--debug", action="store_true", help="Print debug info to stderr.")
     return parser.parse_args()
 
@@ -86,7 +89,59 @@ def score_at(scores, index: int) -> float:
     return float(arr.flat[index])
 
 
-def iter_prompt_segments(processor, state, prompt: str, threshold: float, image_size: tuple[int, int], log) -> Iterable[dict]:
+def binary_mask(mask_array) -> np.ndarray:
+    arr = to_numpy(mask_array)
+    while arr.ndim > 2:
+        arr = arr.squeeze(axis=0) if arr.shape[0] == 1 else arr[0]
+    return arr > 0
+
+
+def mask_bbox(mask_array, fallback_box) -> dict[str, float]:
+    mask = binary_mask(mask_array)
+    ys, xs = np.nonzero(mask)
+    if xs.size == 0 or ys.size == 0:
+        return box_to_xywh(fallback_box)
+    x1 = float(xs.min())
+    y1 = float(ys.min())
+    x2 = float(xs.max() + 1)
+    y2 = float(ys.max() + 1)
+    return {"x": x1, "y": y1, "width": max(1.0, x2 - x1), "height": max(1.0, y2 - y1)}
+
+
+def area_ratio(box: dict[str, float], image_size: tuple[int, int]) -> float:
+    target_w, target_h = image_size
+    return (box["width"] * box["height"]) / max(1.0, float(target_w * target_h))
+
+
+def iou(a: dict[str, float], b: dict[str, float]) -> float:
+    ax2 = a["x"] + a["width"]
+    ay2 = a["y"] + a["height"]
+    bx2 = b["x"] + b["width"]
+    by2 = b["y"] + b["height"]
+    ix1 = max(a["x"], b["x"])
+    iy1 = max(a["y"], b["y"])
+    ix2 = min(ax2, bx2)
+    iy2 = min(ay2, by2)
+    inter = max(0.0, ix2 - ix1) * max(0.0, iy2 - iy1)
+    if inter <= 0:
+        return 0.0
+    union = a["width"] * a["height"] + b["width"] * b["height"] - inter
+    return inter / max(union, 1e-6)
+
+
+def dedupe_segments(segments: list[dict], nms_iou: float, max_segments: int) -> list[dict]:
+    ordered = sorted(segments, key=lambda s: (float(s.get("score", 0)), s["bbox"]["width"] * s["bbox"]["height"]), reverse=True)
+    kept: list[dict] = []
+    for segment in ordered:
+        if any(iou(segment["bbox"], existing["bbox"]) >= nms_iou for existing in kept):
+            continue
+        kept.append(segment)
+        if len(kept) >= max_segments:
+            break
+    return kept
+
+
+def iter_prompt_segments(processor, state, prompt: str, threshold: float, image_size: tuple[int, int], min_area_ratio: float, max_area_ratio: float, log) -> Iterable[dict]:
     output = processor.set_text_prompt(prompt=prompt, state=state)
     masks = output.get("masks")
     boxes = output.get("boxes")
@@ -111,11 +166,16 @@ def iter_prompt_segments(processor, state, prompt: str, threshold: float, image_
         try:
             box = boxes_np[index]
             mask = masks_np[index]
+            bbox = mask_bbox(mask, box)
+            ratio = area_ratio(bbox, image_size)
+            if ratio < min_area_ratio or ratio > max_area_ratio:
+                log(f"  - skip idx={index} area_ratio={ratio:.4f} outside [{min_area_ratio}, {max_area_ratio}]")
+                continue
             yield {
                 "id": f"{prompt.replace(' ', '-')}-{index + 1}",
                 "label": prompt,
                 "score": score,
-                "bbox": box_to_xywh(box),
+                "bbox": bbox,
                 "maskDataUrl": mask_to_data_url(mask, target_w, target_h),
             }
         except Exception as exc:
@@ -152,23 +212,25 @@ def main() -> int:
     state = processor.set_image(image)
     log(f"set_image done in {time.time()-t1:.2f}s")
 
-    seen: set[tuple[int, int, int, int]] = set()
-    segments: list[dict] = []
+    candidates: list[dict] = []
     prompts = [p.strip() for p in args.prompts.split(",") if p.strip()]
     log(f"prompts: {prompts}")
 
     for prompt in prompts:
-        for segment in iter_prompt_segments(processor, state, prompt, args.score_threshold, (target_w, target_h), log):
-            box = segment["bbox"]
-            key = (round(box["x"]), round(box["y"]), round(box["width"]), round(box["height"]))
-            if key in seen:
-                continue
-            seen.add(key)
-            segments.append(segment)
-            if len(segments) >= args.max_segments:
-                break
-        if len(segments) >= args.max_segments:
-            break
+        for segment in iter_prompt_segments(
+            processor,
+            state,
+            prompt,
+            args.score_threshold,
+            (target_w, target_h),
+            args.min_area_ratio,
+            args.max_area_ratio,
+            log,
+        ):
+            candidates.append(segment)
+
+    segments = dedupe_segments(candidates, args.nms_iou, args.max_segments)
+    log(f"kept {len(segments)} of {len(candidates)} candidate(s) after NMS")
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(

--- a/scripts/sam3-magic-layer-mlx.py
+++ b/scripts/sam3-magic-layer-mlx.py
@@ -47,6 +47,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--min-area-ratio", type=float, default=0.002, help="Drop masks smaller than this fraction of the image.")
     parser.add_argument("--max-area-ratio", type=float, default=0.75, help="Drop masks larger than this fraction of the image.")
     parser.add_argument("--nms-iou", type=float, default=0.72, help="Drop lower-scoring boxes with IoU above this value.")
+    parser.add_argument("--layout-segments", type=int, default=8, help="Maximum no-dependency layout/color components to add for slide-like images.")
+    parser.add_argument("--layout-distance-threshold", type=float, default=42.0, help="RGB distance from border-estimated background for layout component extraction.")
     parser.add_argument("--debug", action="store_true", help="Print debug info to stderr.")
     return parser.parse_args()
 
@@ -129,8 +131,60 @@ def iou(a: dict[str, float], b: dict[str, float]) -> float:
     return inter / max(union, 1e-6)
 
 
+def intersection_area(a: dict[str, float], b: dict[str, float]) -> float:
+    ax2 = a["x"] + a["width"]
+    ay2 = a["y"] + a["height"]
+    bx2 = b["x"] + b["width"]
+    by2 = b["y"] + b["height"]
+    ix1 = max(a["x"], b["x"])
+    iy1 = max(a["y"], b["y"])
+    ix2 = min(ax2, bx2)
+    iy2 = min(ay2, by2)
+    return max(0.0, ix2 - ix1) * max(0.0, iy2 - iy1)
+
+
+def box_area(box: dict[str, float]) -> float:
+    return max(0.0, box["width"]) * max(0.0, box["height"])
+
+
+def containment_ratio(child: dict[str, float], parent: dict[str, float]) -> float:
+    return intersection_area(child, parent) / max(box_area(child), 1e-6)
+
+
+def suppress_nested_sam_parts(segments: list[dict]) -> list[dict]:
+    kept: list[dict] = []
+    for child in segments:
+        if child.get("source") == "layout":
+            kept.append(child)
+            continue
+        child_box = child["bbox"]
+        child_area = box_area(child_box)
+        suppress = False
+        for parent in segments:
+            if parent is child or parent.get("source") == "layout":
+                continue
+            parent_box = parent["bbox"]
+            parent_area = box_area(parent_box)
+            if parent_area < child_area * 1.35:
+                continue
+            if containment_ratio(child_box, parent_box) < 0.82:
+                continue
+            if float(parent.get("score", 0)) < float(child.get("score", 0)) * 0.35:
+                continue
+            suppress = True
+            break
+        if not suppress:
+            kept.append(child)
+    return kept
+
+
 def dedupe_segments(segments: list[dict], nms_iou: float, max_segments: int) -> list[dict]:
-    ordered = sorted(segments, key=lambda s: (float(s.get("score", 0)), s["bbox"]["width"] * s["bbox"]["height"]), reverse=True)
+    candidates = suppress_nested_sam_parts(segments)
+    ordered = sorted(
+        candidates,
+        key=lambda s: (float(s.get("score", 0)), min(box_area(s["bbox"]), 1_000_000.0)),
+        reverse=True,
+    )
     kept: list[dict] = []
     for segment in ordered:
         if any(iou(segment["bbox"], existing["bbox"]) >= nms_iou for existing in kept):
@@ -139,6 +193,94 @@ def dedupe_segments(segments: list[dict], nms_iou: float, max_segments: int) -> 
         if len(kept) >= max_segments:
             break
     return kept
+
+
+def connected_components(mask: "object") -> list[tuple[int, int, int, int, int]]:
+    import numpy as np
+
+    h, w = mask.shape
+    visited = np.zeros((h, w), dtype=bool)
+    components: list[tuple[int, int, int, int, int]] = []
+    ys, xs = np.nonzero(mask)
+    for start_x, start_y in zip(xs.tolist(), ys.tolist()):
+        if visited[start_y, start_x]:
+            continue
+        stack = [(start_x, start_y)]
+        visited[start_y, start_x] = True
+        min_x = max_x = start_x
+        min_y = max_y = start_y
+        area = 0
+        while stack:
+            x, y = stack.pop()
+            area += 1
+            min_x = min(min_x, x)
+            max_x = max(max_x, x)
+            min_y = min(min_y, y)
+            max_y = max(max_y, y)
+            for nx, ny in ((x - 1, y), (x + 1, y), (x, y - 1), (x, y + 1)):
+                if nx < 0 or ny < 0 or nx >= w or ny >= h or visited[ny, nx] or not mask[ny, nx]:
+                    continue
+                visited[ny, nx] = True
+                stack.append((nx, ny))
+        components.append((min_x, min_y, max_x + 1, max_y + 1, area))
+    return components
+
+
+def iter_layout_segments(image, image_size: tuple[int, int], max_segments: int, threshold: float, min_area_ratio: float, max_area_ratio: float) -> Iterable[dict]:
+    import numpy as np
+    from PIL import Image, ImageFilter
+
+    target_w, target_h = image_size
+    arr = np.asarray(image.convert("RGB"), dtype=np.float32)
+    border = np.concatenate([arr[0, :, :], arr[-1, :, :], arr[:, 0, :], arr[:, -1, :]], axis=0)
+    background = np.median(border, axis=0)
+    distance = np.sqrt(((arr - background) ** 2).sum(axis=2))
+    foreground = distance > threshold
+    foreground_ratio = float(foreground.mean())
+    if foreground_ratio < 0.005 or foreground_ratio > 0.78:
+        return
+
+    scale = min(1.0, 420.0 / max(target_w, target_h))
+    small_w = max(1, int(round(target_w * scale)))
+    small_h = max(1, int(round(target_h * scale)))
+    small = Image.fromarray((foreground.astype("uint8") * 255), mode="L").resize((small_w, small_h), resample=Image.Resampling.NEAREST)
+    kernel = max(3, int(round(19 * scale)))
+    if kernel % 2 == 0:
+        kernel += 1
+    small = small.filter(ImageFilter.MaxFilter(kernel))
+    small_mask = np.asarray(small) > 0
+
+    components = []
+    for sx1, sy1, sx2, sy2, _area in connected_components(small_mask):
+        x1 = max(0, int(sx1 / scale) - 3)
+        y1 = max(0, int(sy1 / scale) - 3)
+        x2 = min(target_w, int(np.ceil(sx2 / scale)) + 3)
+        y2 = min(target_h, int(np.ceil(sy2 / scale)) + 3)
+        if x2 <= x1 or y2 <= y1:
+            continue
+        component_mask = np.zeros((target_h, target_w), dtype=bool)
+        component_mask[y1:y2, x1:x2] = foreground[y1:y2, x1:x2]
+        bbox = mask_bbox(component_mask, [x1, y1, x2, y2])
+        ratio = area_ratio(bbox, image_size)
+        layout_max_area_ratio = min(max_area_ratio, 0.45)
+        if ratio < min_area_ratio or ratio > layout_max_area_ratio:
+            continue
+        components.append((bbox["width"] * bbox["height"], bbox, component_mask))
+
+    components.sort(key=lambda item: item[0], reverse=True)
+    emitted = 0
+    for _area, bbox, component_mask in components:
+        emitted += 1
+        yield {
+            "id": f"layout-{emitted}",
+            "label": "layout element",
+            "score": 0.45,
+            "source": "layout",
+            "bbox": bbox,
+            "maskDataUrl": mask_to_data_url(component_mask, target_w, target_h),
+        }
+        if emitted >= max_segments:
+            break
 
 
 def iter_prompt_segments(processor, state, prompt: str, threshold: float, image_size: tuple[int, int], min_area_ratio: float, max_area_ratio: float, log) -> Iterable[dict]:
@@ -175,6 +317,7 @@ def iter_prompt_segments(processor, state, prompt: str, threshold: float, image_
                 "id": f"{prompt.replace(' ', '-')}-{index + 1}",
                 "label": prompt,
                 "score": score,
+                "source": "sam",
                 "bbox": bbox,
                 "maskDataUrl": mask_to_data_url(mask, target_w, target_h),
             }
@@ -228,6 +371,9 @@ def main() -> int:
             log,
         ):
             candidates.append(segment)
+
+    if args.layout_segments > 0:
+        candidates.extend(iter_layout_segments(image, (target_w, target_h), args.layout_segments, args.layout_distance_threshold, args.min_area_ratio, args.max_area_ratio))
 
     segments = dedupe_segments(candidates, args.nms_iou, args.max_segments)
     log(f"kept {len(segments)} of {len(candidates)} candidate(s) after NMS")

--- a/scripts/sam3-magic-layer-mlx.py
+++ b/scripts/sam3-magic-layer-mlx.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""mlx_sam3 adapter for BananaTape Magic Layer (Apple Silicon).
+
+Bridges Deekshith-Dade/mlx_sam3 (MLX SAM3 port for M-series Macs) to
+BananaTape's /api/magic-layer JSON contract:
+
+  {"segments": [{"id", "label", "score", "bbox":{"x","y","width","height"},
+                 "maskDataUrl": "data:image/png;base64,..."}]}
+
+BananaTape's auto-installer calls this script with:
+  --input <png path>  --output <json path>  [--prompts a,b,c]
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import io
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import mlx.core as mx
+from PIL import Image
+
+from sam3 import build_sam3_image_model
+from sam3.model.sam3_image_processor import Sam3Processor
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run mlx_sam3 and emit BananaTape Magic Layer segments JSON.")
+    parser.add_argument("positional_input", nargs="?", help="Input image path (fallback positional form).")
+    parser.add_argument("positional_output", nargs="?", help="Output JSON path (fallback positional form).")
+    parser.add_argument("--input", dest="input_path", help="Input image path.")
+    parser.add_argument("--output", dest="output_path", help="Output JSON path.")
+    parser.add_argument(
+        "--prompts",
+        default="text,logo,person,animal,plant,product,object,foreground,subject,frame,table",
+        help="Comma-separated SAM 3 concept prompts to try.",
+    )
+    parser.add_argument("--score-threshold", type=float, default=0.35, help="Minimum SAM 3 score to keep.")
+    parser.add_argument("--max-segments", type=int, default=24, help="Maximum number of segments to emit.")
+    parser.add_argument("--confidence-threshold", type=float, default=0.3, help="Sam3Processor confidence threshold.")
+    parser.add_argument("--debug", action="store_true", help="Print debug info to stderr.")
+    return parser.parse_args()
+
+
+def to_numpy(arr) -> np.ndarray:
+    if isinstance(arr, mx.array):
+        return np.asarray(arr)
+    if hasattr(arr, "detach"):
+        return arr.detach().cpu().numpy()
+    return np.asarray(arr)
+
+
+def mask_to_data_url(mask_array, target_w: int, target_h: int) -> str:
+    arr = to_numpy(mask_array)
+    while arr.ndim > 2:
+        arr = arr.squeeze(axis=0) if arr.shape[0] == 1 else arr[0]
+    alpha = (arr > 0).astype("uint8") * 255
+    image = Image.fromarray(alpha, mode="L")
+    if image.size != (target_w, target_h):
+        image = image.resize((target_w, target_h), resample=Image.NEAREST)
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return "data:image/png;base64," + base64.b64encode(buffer.getvalue()).decode("ascii")
+
+
+def box_to_xywh(box) -> dict[str, float]:
+    arr = to_numpy(box).astype(float).flatten()
+    if arr.size != 4:
+        raise ValueError(f"Expected 4 box values, got {arr.size}")
+    x1, y1, x2, y2 = arr.tolist()
+    return {"x": x1, "y": y1, "width": max(1.0, x2 - x1), "height": max(1.0, y2 - y1)}
+
+
+def score_at(scores, index: int) -> float:
+    if scores is None:
+        return 1.0
+    arr = to_numpy(scores)
+    if arr.size == 0:
+        return 1.0
+    return float(arr.flat[index])
+
+
+def iter_prompt_segments(processor, state, prompt: str, threshold: float, image_size: tuple[int, int], log) -> Iterable[dict]:
+    output = processor.set_text_prompt(prompt=prompt, state=state)
+    masks = output.get("masks")
+    boxes = output.get("boxes")
+    scores = output.get("scores")
+
+    if masks is None or boxes is None:
+        log(f"[prompt={prompt}] no masks/boxes in output")
+        return
+
+    masks_np = to_numpy(masks)
+    boxes_np = to_numpy(boxes)
+    n = boxes_np.shape[0] if boxes_np.ndim >= 2 else 0
+    log(f"[prompt={prompt}] {n} candidate(s)")
+
+    target_w, target_h = image_size
+
+    for index in range(n):
+        score = score_at(scores, index)
+        if score < threshold:
+            log(f"  - skip idx={index} score={score:.3f} < {threshold}")
+            continue
+        try:
+            box = boxes_np[index]
+            mask = masks_np[index]
+            yield {
+                "id": f"{prompt.replace(' ', '-')}-{index + 1}",
+                "label": prompt,
+                "score": score,
+                "bbox": box_to_xywh(box),
+                "maskDataUrl": mask_to_data_url(mask, target_w, target_h),
+            }
+        except Exception as exc:
+            log(f"  - error idx={index}: {exc}")
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = Path(args.input_path or args.positional_input or "")
+    output_path = Path(args.output_path or args.positional_output or "")
+    if not input_path.is_file():
+        print(f"input path does not exist: {input_path}", file=sys.stderr)
+        return 2
+    if not output_path:
+        print("output path is required", file=sys.stderr)
+        return 2
+
+    def log(msg: str) -> None:
+        if args.debug:
+            print(msg, file=sys.stderr, flush=True)
+
+    t0 = time.time()
+    log(f"loading image: {input_path}")
+    image = Image.open(input_path).convert("RGB")
+    target_w, target_h = image.size
+    log(f"image size: {target_w}x{target_h}")
+
+    log("loading mlx_sam3 model (weights cached after first run)...")
+    model = build_sam3_image_model()
+    processor = Sam3Processor(model, confidence_threshold=args.confidence_threshold)
+    log(f"model ready in {time.time()-t0:.1f}s")
+
+    t1 = time.time()
+    state = processor.set_image(image)
+    log(f"set_image done in {time.time()-t1:.2f}s")
+
+    seen: set[tuple[int, int, int, int]] = set()
+    segments: list[dict] = []
+    prompts = [p.strip() for p in args.prompts.split(",") if p.strip()]
+    log(f"prompts: {prompts}")
+
+    for prompt in prompts:
+        for segment in iter_prompt_segments(processor, state, prompt, args.score_threshold, (target_w, target_h), log):
+            box = segment["bbox"]
+            key = (round(box["x"]), round(box["y"]), round(box["width"]), round(box["height"]))
+            if key in seen:
+                continue
+            seen.add(key)
+            segments.append(segment)
+            if len(segments) >= args.max_segments:
+                break
+        if len(segments) >= args.max_segments:
+            break
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps({"segments": segments}, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    log(f"wrote {len(segments)} segment(s) to {output_path} in {time.time()-t0:.1f}s total")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sam3-magic-layer.py
+++ b/scripts/sam3-magic-layer.py
@@ -34,30 +34,42 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output", dest="output_path", help="Output JSON path.")
     parser.add_argument(
         "--prompts",
-        default="text,logo,person,product,object,foreground",
-        help="Comma-separated SAM 3 concept prompts to try.",
+        default="person,animal,cat,dog,bird,plant,flower,tree,food,product,bottle,cup,chair,table,car,building,text,logo",
+        help="Comma-separated SAM 3 concept prompts to try. Specific nouns work much better than generic 'object'.",
     )
-    parser.add_argument("--score-threshold", type=float, default=0.35, help="Minimum SAM 3 score to keep.")
+    parser.add_argument("--score-threshold", type=float, default=0.25, help="Minimum SAM 3 score to keep after model inference.")
     parser.add_argument("--max-segments", type=int, default=24, help="Maximum number of segments to emit.")
+    parser.add_argument("--min-area-ratio", type=float, default=0.002, help="Drop masks smaller than this fraction of the image.")
+    parser.add_argument("--max-area-ratio", type=float, default=0.75, help="Drop masks larger than this fraction of the image.")
+    parser.add_argument("--nms-iou", type=float, default=0.72, help="Drop lower-scoring boxes with IoU above this value.")
     return parser.parse_args()
+
+
+def to_numpy(value):
+    import numpy as np
+
+    return value.detach().cpu().numpy() if hasattr(value, "detach") else np.asarray(value)
 
 
 def data_url_from_mask(mask) -> str:
     import numpy as np
     from PIL import Image
 
-    array = mask.detach().cpu().numpy() if hasattr(mask, "detach") else np.asarray(mask)
-    if array.ndim > 2:
-      array = array.squeeze()
+    array = to_numpy(mask)
+    while array.ndim > 2:
+        array = array.squeeze(axis=0) if array.shape[0] == 1 else array[0]
     alpha = (array > 0).astype("uint8") * 255
-    image = Image.fromarray(alpha, mode="L")
+    rgba = np.zeros((*alpha.shape, 4), dtype="uint8")
+    rgba[..., :3] = 255
+    rgba[..., 3] = alpha
+    image = Image.fromarray(rgba, mode="RGBA")
     buffer = io.BytesIO()
     image.save(buffer, format="PNG")
     return "data:image/png;base64," + base64.b64encode(buffer.getvalue()).decode("ascii")
 
 
 def box_to_xywh(box) -> dict[str, float]:
-    values = box.detach().cpu().tolist() if hasattr(box, "detach") else list(box)
+    values = to_numpy(box).astype(float).flatten().tolist()
     if len(values) != 4:
         raise ValueError(f"Expected 4 box values, got {len(values)}")
     x1, y1, x2, y2 = [float(v) for v in values]
@@ -67,13 +79,67 @@ def box_to_xywh(box) -> dict[str, float]:
 def score_at(scores, index: int) -> float:
     if scores is None:
         return 1.0
-    value = scores[index]
-    if hasattr(value, "detach"):
-        return float(value.detach().cpu().item())
-    return float(value)
+    arr = to_numpy(scores)
+    if arr.size == 0:
+        return 1.0
+    return float(arr.flat[index])
 
 
-def iter_prompt_segments(processor, state, prompt: str, threshold: float) -> Iterable[dict]:
+def binary_mask(mask) -> "object":
+    arr = to_numpy(mask)
+    while arr.ndim > 2:
+        arr = arr.squeeze(axis=0) if arr.shape[0] == 1 else arr[0]
+    return arr > 0
+
+
+def mask_bbox(mask, fallback_box) -> dict[str, float]:
+    import numpy as np
+
+    mask_array = binary_mask(mask)
+    ys, xs = np.nonzero(mask_array)
+    if xs.size == 0 or ys.size == 0:
+        return box_to_xywh(fallback_box)
+    x1 = float(xs.min())
+    y1 = float(ys.min())
+    x2 = float(xs.max() + 1)
+    y2 = float(ys.max() + 1)
+    return {"x": x1, "y": y1, "width": max(1.0, x2 - x1), "height": max(1.0, y2 - y1)}
+
+
+def area_ratio(box: dict[str, float], image_size: tuple[int, int]) -> float:
+    target_w, target_h = image_size
+    return (box["width"] * box["height"]) / max(1.0, float(target_w * target_h))
+
+
+def iou(a: dict[str, float], b: dict[str, float]) -> float:
+    ax2 = a["x"] + a["width"]
+    ay2 = a["y"] + a["height"]
+    bx2 = b["x"] + b["width"]
+    by2 = b["y"] + b["height"]
+    ix1 = max(a["x"], b["x"])
+    iy1 = max(a["y"], b["y"])
+    ix2 = min(ax2, bx2)
+    iy2 = min(ay2, by2)
+    inter = max(0.0, ix2 - ix1) * max(0.0, iy2 - iy1)
+    if inter <= 0:
+        return 0.0
+    union = a["width"] * a["height"] + b["width"] * b["height"] - inter
+    return inter / max(union, 1e-6)
+
+
+def dedupe_segments(segments: list[dict], nms_iou: float, max_segments: int) -> list[dict]:
+    ordered = sorted(segments, key=lambda s: (float(s.get("score", 0)), s["bbox"]["width"] * s["bbox"]["height"]), reverse=True)
+    kept: list[dict] = []
+    for segment in ordered:
+        if any(iou(segment["bbox"], existing["bbox"]) >= nms_iou for existing in kept):
+            continue
+        kept.append(segment)
+        if len(kept) >= max_segments:
+            break
+    return kept
+
+
+def iter_prompt_segments(processor, state, prompt: str, threshold: float, image_size: tuple[int, int], min_area_ratio: float, max_area_ratio: float) -> Iterable[dict]:
     output = processor.set_text_prompt(state=state, prompt=prompt)
     masks = output.get("masks", [])
     boxes = output.get("boxes", [])
@@ -83,11 +149,15 @@ def iter_prompt_segments(processor, state, prompt: str, threshold: float) -> Ite
         score = score_at(scores, index)
         if score < threshold:
             continue
+        bbox = mask_bbox(mask, box)
+        ratio = area_ratio(bbox, image_size)
+        if ratio < min_area_ratio or ratio > max_area_ratio:
+            continue
         yield {
             "id": f"{prompt.replace(' ', '-')}-{index + 1}",
             "label": prompt,
             "score": score,
-            "bbox": box_to_xywh(box),
+            "bbox": bbox,
             "maskDataUrl": data_url_from_mask(mask),
         }
 
@@ -113,21 +183,14 @@ def main() -> int:
     image = Image.open(input_path).convert("RGB")
     state = processor.set_image(image)
 
-    seen: set[tuple[int, int, int, int]] = set()
-    segments: list[dict] = []
+    candidates: list[dict] = []
     prompts = [prompt.strip() for prompt in args.prompts.split(",") if prompt.strip()]
+    image_size = image.size
     for prompt in prompts:
-        for segment in iter_prompt_segments(processor, state, prompt, args.score_threshold):
-            box = segment["bbox"]
-            key = (round(box["x"]), round(box["y"]), round(box["width"]), round(box["height"]))
-            if key in seen:
-                continue
-            seen.add(key)
-            segments.append(segment)
-            if len(segments) >= args.max_segments:
-                break
-        if len(segments) >= args.max_segments:
-            break
+        for segment in iter_prompt_segments(processor, state, prompt, args.score_threshold, image_size, args.min_area_ratio, args.max_area_ratio):
+            candidates.append(segment)
+
+    segments = dedupe_segments(candidates, args.nms_iou, args.max_segments)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps({"segments": segments}, ensure_ascii=False, indent=2), encoding="utf-8")

--- a/scripts/sam3-magic-layer.py
+++ b/scripts/sam3-magic-layer.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""SAM 3 wrapper for BananaTape Magic Layer.
+
+This script adapts Meta's official `facebookresearch/sam3` Python API to the
+JSON contract expected by BananaTape's `/api/magic-layer` route.
+
+Requirements are intentionally external to BananaTape's npm package:
+  - Python 3.12+
+  - a working SAM 3 installation (`pip install -e .` from facebookresearch/sam3)
+  - accepted/downloadable SAM 3 checkpoints through the official mechanism
+  - a PyTorch runtime supported by the SAM 3 package
+
+Example:
+  python3 scripts/sam3-magic-layer.py --input image.png --output segments.json \
+    --prompts text,logo,person,product,object
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import io
+import json
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run SAM 3 and emit BananaTape Magic Layer segments JSON.")
+    parser.add_argument("positional_input", nargs="?", help="Input image path (fallback positional form).")
+    parser.add_argument("positional_output", nargs="?", help="Output JSON path (fallback positional form).")
+    parser.add_argument("--input", dest="input_path", help="Input image path.")
+    parser.add_argument("--output", dest="output_path", help="Output JSON path.")
+    parser.add_argument(
+        "--prompts",
+        default="text,logo,person,product,object,foreground",
+        help="Comma-separated SAM 3 concept prompts to try.",
+    )
+    parser.add_argument("--score-threshold", type=float, default=0.35, help="Minimum SAM 3 score to keep.")
+    parser.add_argument("--max-segments", type=int, default=24, help="Maximum number of segments to emit.")
+    return parser.parse_args()
+
+
+def data_url_from_mask(mask) -> str:
+    import numpy as np
+    from PIL import Image
+
+    array = mask.detach().cpu().numpy() if hasattr(mask, "detach") else np.asarray(mask)
+    if array.ndim > 2:
+      array = array.squeeze()
+    alpha = (array > 0).astype("uint8") * 255
+    image = Image.fromarray(alpha, mode="L")
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return "data:image/png;base64," + base64.b64encode(buffer.getvalue()).decode("ascii")
+
+
+def box_to_xywh(box) -> dict[str, float]:
+    values = box.detach().cpu().tolist() if hasattr(box, "detach") else list(box)
+    if len(values) != 4:
+        raise ValueError(f"Expected 4 box values, got {len(values)}")
+    x1, y1, x2, y2 = [float(v) for v in values]
+    return {"x": x1, "y": y1, "width": max(1.0, x2 - x1), "height": max(1.0, y2 - y1)}
+
+
+def score_at(scores, index: int) -> float:
+    if scores is None:
+        return 1.0
+    value = scores[index]
+    if hasattr(value, "detach"):
+        return float(value.detach().cpu().item())
+    return float(value)
+
+
+def iter_prompt_segments(processor, state, prompt: str, threshold: float) -> Iterable[dict]:
+    output = processor.set_text_prompt(state=state, prompt=prompt)
+    masks = output.get("masks", [])
+    boxes = output.get("boxes", [])
+    scores = output.get("scores")
+
+    for index, (mask, box) in enumerate(zip(masks, boxes)):
+        score = score_at(scores, index)
+        if score < threshold:
+            continue
+        yield {
+            "id": f"{prompt.replace(' ', '-')}-{index + 1}",
+            "label": prompt,
+            "score": score,
+            "bbox": box_to_xywh(box),
+            "maskDataUrl": data_url_from_mask(mask),
+        }
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = Path(args.input_path or args.positional_input or "")
+    output_path = Path(args.output_path or args.positional_output or "")
+    if not input_path.is_file() or not output_path:
+        print("input and output paths are required", file=sys.stderr)
+        return 2
+
+    try:
+        from PIL import Image
+        from sam3.model_builder import build_sam3_image_model
+        from sam3.model.sam3_image_processor import Sam3Processor
+    except Exception as exc:  # pragma: no cover - depends on external SAM 3 env
+        print(f"SAM 3 Python dependencies are not available: {exc}", file=sys.stderr)
+        return 3
+
+    model = build_sam3_image_model()
+    processor = Sam3Processor(model)
+    image = Image.open(input_path).convert("RGB")
+    state = processor.set_image(image)
+
+    seen: set[tuple[int, int, int, int]] = set()
+    segments: list[dict] = []
+    prompts = [prompt.strip() for prompt in args.prompts.split(",") if prompt.strip()]
+    for prompt in prompts:
+        for segment in iter_prompt_segments(processor, state, prompt, args.score_threshold):
+            box = segment["bbox"]
+            key = (round(box["x"]), round(box["y"]), round(box["width"]), round(box["height"]))
+            if key in seen:
+                continue
+            seen.add(key)
+            segments.append(segment)
+            if len(segments) >= args.max_segments:
+                break
+        if len(segments) >= args.max_segments:
+            break
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps({"segments": segments}, ensure_ascii=False, indent=2), encoding="utf-8")
+    return 0 if segments else 4
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sam3-magic-layer.py
+++ b/scripts/sam3-magic-layer.py
@@ -42,6 +42,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--min-area-ratio", type=float, default=0.002, help="Drop masks smaller than this fraction of the image.")
     parser.add_argument("--max-area-ratio", type=float, default=0.75, help="Drop masks larger than this fraction of the image.")
     parser.add_argument("--nms-iou", type=float, default=0.72, help="Drop lower-scoring boxes with IoU above this value.")
+    parser.add_argument("--layout-segments", type=int, default=8, help="Maximum no-dependency layout/color components to add for slide-like images.")
+    parser.add_argument("--layout-distance-threshold", type=float, default=42.0, help="RGB distance from border-estimated background for layout component extraction.")
     return parser.parse_args()
 
 
@@ -127,8 +129,60 @@ def iou(a: dict[str, float], b: dict[str, float]) -> float:
     return inter / max(union, 1e-6)
 
 
+def intersection_area(a: dict[str, float], b: dict[str, float]) -> float:
+    ax2 = a["x"] + a["width"]
+    ay2 = a["y"] + a["height"]
+    bx2 = b["x"] + b["width"]
+    by2 = b["y"] + b["height"]
+    ix1 = max(a["x"], b["x"])
+    iy1 = max(a["y"], b["y"])
+    ix2 = min(ax2, bx2)
+    iy2 = min(ay2, by2)
+    return max(0.0, ix2 - ix1) * max(0.0, iy2 - iy1)
+
+
+def box_area(box: dict[str, float]) -> float:
+    return max(0.0, box["width"]) * max(0.0, box["height"])
+
+
+def containment_ratio(child: dict[str, float], parent: dict[str, float]) -> float:
+    return intersection_area(child, parent) / max(box_area(child), 1e-6)
+
+
+def suppress_nested_sam_parts(segments: list[dict]) -> list[dict]:
+    kept: list[dict] = []
+    for child in segments:
+        if child.get("source") == "layout":
+            kept.append(child)
+            continue
+        child_box = child["bbox"]
+        child_area = box_area(child_box)
+        suppress = False
+        for parent in segments:
+            if parent is child or parent.get("source") == "layout":
+                continue
+            parent_box = parent["bbox"]
+            parent_area = box_area(parent_box)
+            if parent_area < child_area * 1.35:
+                continue
+            if containment_ratio(child_box, parent_box) < 0.82:
+                continue
+            if float(parent.get("score", 0)) < float(child.get("score", 0)) * 0.35:
+                continue
+            suppress = True
+            break
+        if not suppress:
+            kept.append(child)
+    return kept
+
+
 def dedupe_segments(segments: list[dict], nms_iou: float, max_segments: int) -> list[dict]:
-    ordered = sorted(segments, key=lambda s: (float(s.get("score", 0)), s["bbox"]["width"] * s["bbox"]["height"]), reverse=True)
+    candidates = suppress_nested_sam_parts(segments)
+    ordered = sorted(
+        candidates,
+        key=lambda s: (float(s.get("score", 0)), min(box_area(s["bbox"]), 1_000_000.0)),
+        reverse=True,
+    )
     kept: list[dict] = []
     for segment in ordered:
         if any(iou(segment["bbox"], existing["bbox"]) >= nms_iou for existing in kept):
@@ -137,6 +191,94 @@ def dedupe_segments(segments: list[dict], nms_iou: float, max_segments: int) -> 
         if len(kept) >= max_segments:
             break
     return kept
+
+
+def connected_components(mask: "object") -> list[tuple[int, int, int, int, int]]:
+    import numpy as np
+
+    h, w = mask.shape
+    visited = np.zeros((h, w), dtype=bool)
+    components: list[tuple[int, int, int, int, int]] = []
+    ys, xs = np.nonzero(mask)
+    for start_x, start_y in zip(xs.tolist(), ys.tolist()):
+        if visited[start_y, start_x]:
+            continue
+        stack = [(start_x, start_y)]
+        visited[start_y, start_x] = True
+        min_x = max_x = start_x
+        min_y = max_y = start_y
+        area = 0
+        while stack:
+            x, y = stack.pop()
+            area += 1
+            min_x = min(min_x, x)
+            max_x = max(max_x, x)
+            min_y = min(min_y, y)
+            max_y = max(max_y, y)
+            for nx, ny in ((x - 1, y), (x + 1, y), (x, y - 1), (x, y + 1)):
+                if nx < 0 or ny < 0 or nx >= w or ny >= h or visited[ny, nx] or not mask[ny, nx]:
+                    continue
+                visited[ny, nx] = True
+                stack.append((nx, ny))
+        components.append((min_x, min_y, max_x + 1, max_y + 1, area))
+    return components
+
+
+def iter_layout_segments(image, image_size: tuple[int, int], max_segments: int, threshold: float, min_area_ratio: float, max_area_ratio: float) -> Iterable[dict]:
+    import numpy as np
+    from PIL import Image, ImageFilter
+
+    target_w, target_h = image_size
+    arr = np.asarray(image.convert("RGB"), dtype=np.float32)
+    border = np.concatenate([arr[0, :, :], arr[-1, :, :], arr[:, 0, :], arr[:, -1, :]], axis=0)
+    background = np.median(border, axis=0)
+    distance = np.sqrt(((arr - background) ** 2).sum(axis=2))
+    foreground = distance > threshold
+    foreground_ratio = float(foreground.mean())
+    if foreground_ratio < 0.005 or foreground_ratio > 0.78:
+        return
+
+    scale = min(1.0, 420.0 / max(target_w, target_h))
+    small_w = max(1, int(round(target_w * scale)))
+    small_h = max(1, int(round(target_h * scale)))
+    small = Image.fromarray((foreground.astype("uint8") * 255), mode="L").resize((small_w, small_h), resample=Image.Resampling.NEAREST)
+    kernel = max(3, int(round(19 * scale)))
+    if kernel % 2 == 0:
+        kernel += 1
+    small = small.filter(ImageFilter.MaxFilter(kernel))
+    small_mask = np.asarray(small) > 0
+
+    components = []
+    for sx1, sy1, sx2, sy2, _area in connected_components(small_mask):
+        x1 = max(0, int(sx1 / scale) - 3)
+        y1 = max(0, int(sy1 / scale) - 3)
+        x2 = min(target_w, int(np.ceil(sx2 / scale)) + 3)
+        y2 = min(target_h, int(np.ceil(sy2 / scale)) + 3)
+        if x2 <= x1 or y2 <= y1:
+            continue
+        component_mask = np.zeros((target_h, target_w), dtype=bool)
+        component_mask[y1:y2, x1:x2] = foreground[y1:y2, x1:x2]
+        bbox = mask_bbox(component_mask, [x1, y1, x2, y2])
+        ratio = area_ratio(bbox, image_size)
+        layout_max_area_ratio = min(max_area_ratio, 0.45)
+        if ratio < min_area_ratio or ratio > layout_max_area_ratio:
+            continue
+        components.append((bbox["width"] * bbox["height"], bbox, component_mask))
+
+    components.sort(key=lambda item: item[0], reverse=True)
+    emitted = 0
+    for _area, bbox, component_mask in components:
+        emitted += 1
+        yield {
+            "id": f"layout-{emitted}",
+            "label": "layout element",
+            "score": 0.45,
+            "source": "layout",
+            "bbox": bbox,
+            "maskDataUrl": data_url_from_mask(component_mask),
+        }
+        if emitted >= max_segments:
+            break
 
 
 def iter_prompt_segments(processor, state, prompt: str, threshold: float, image_size: tuple[int, int], min_area_ratio: float, max_area_ratio: float) -> Iterable[dict]:
@@ -157,6 +299,7 @@ def iter_prompt_segments(processor, state, prompt: str, threshold: float, image_
             "id": f"{prompt.replace(' ', '-')}-{index + 1}",
             "label": prompt,
             "score": score,
+            "source": "sam",
             "bbox": bbox,
             "maskDataUrl": data_url_from_mask(mask),
         }
@@ -189,6 +332,9 @@ def main() -> int:
     for prompt in prompts:
         for segment in iter_prompt_segments(processor, state, prompt, args.score_threshold, image_size, args.min_area_ratio, args.max_area_ratio):
             candidates.append(segment)
+
+    if args.layout_segments > 0:
+        candidates.extend(iter_layout_segments(image, image_size, args.layout_segments, args.layout_distance_threshold, args.min_area_ratio, args.max_area_ratio))
 
     segments = dedupe_segments(candidates, args.nms_iou, args.max_segments)
 

--- a/src/app/api/magic-layer/route.ts
+++ b/src/app/api/magic-layer/route.ts
@@ -1,0 +1,101 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const execFileAsync = promisify(execFile);
+const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
+
+interface SegmentResponse {
+  id?: string;
+  label?: string;
+  bbox: { x: number; y: number; width: number; height: number };
+  maskDataUrl?: string;
+}
+
+function isFile(value: FormDataEntryValue | null): value is File {
+  return value instanceof File && value.size > 0;
+}
+
+function sanitizeSegments(value: unknown): SegmentResponse[] {
+  const raw = Array.isArray(value) ? value : (value && typeof value === 'object' && Array.isArray((value as { segments?: unknown }).segments) ? (value as { segments: unknown[] }).segments : []);
+  return raw.flatMap((item, index) => {
+    if (!item || typeof item !== 'object') return [];
+    const candidate = item as { id?: unknown; label?: unknown; bbox?: unknown; box?: unknown; maskDataUrl?: unknown; mask?: unknown };
+    const box = candidate.bbox ?? candidate.box;
+    if (!box || typeof box !== 'object') return [];
+    const b = box as { x?: unknown; y?: unknown; width?: unknown; height?: unknown; w?: unknown; h?: unknown };
+    const x = Number(b.x);
+    const y = Number(b.y);
+    const width = Number(b.width ?? b.w);
+    const height = Number(b.height ?? b.h);
+    if (![x, y, width, height].every(Number.isFinite) || width <= 0 || height <= 0) return [];
+    return [{
+      id: typeof candidate.id === 'string' ? candidate.id : `sam3-${index + 1}`,
+      label: typeof candidate.label === 'string' ? candidate.label : `SAM3 layer ${index + 1}`,
+      bbox: { x, y, width, height },
+      maskDataUrl: typeof candidate.maskDataUrl === 'string' ? candidate.maskDataUrl : (typeof candidate.mask === 'string' ? candidate.mask : undefined),
+    }];
+  });
+}
+
+async function runSam3Command(image: File): Promise<SegmentResponse[] | null> {
+  const command = process.env.BANANATAPE_SAM3_COMMAND?.trim();
+  if (!command) return null;
+
+  const dir = await mkdtemp(path.join(/*turbopackIgnore: true*/ tmpdir(), 'bananatape-sam3-'));
+  const inputPath = path.join(dir, 'input.png');
+  const outputPath = path.join(dir, 'segments.json');
+  try {
+    await writeFile(inputPath, Buffer.from(await image.arrayBuffer()));
+    const [bin, ...configuredArgs] = command.split(/\s+/);
+    const args = configuredArgs.map((arg) => arg.replaceAll('{input}', inputPath).replaceAll('{output}', outputPath));
+    if (!args.some((arg) => arg.includes(inputPath))) args.push(inputPath);
+    if (!args.some((arg) => arg.includes(outputPath))) args.push(outputPath);
+    await execFileAsync(bin, args, { timeout: 120_000, maxBuffer: 10 * 1024 * 1024 });
+    const parsed = JSON.parse(await readFile(outputPath, 'utf8'));
+    const segments = sanitizeSegments(parsed);
+    if (segments.length === 0) throw new Error('SAM3 command did not return any usable segments');
+    return segments;
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function fallbackSegments(width: number, height: number): SegmentResponse[] {
+  const w = Math.max(1, Math.round(width));
+  const h = Math.max(1, Math.round(height));
+  return [
+    { id: 'text-band', label: 'Text / foreground band', bbox: { x: Math.round(w * 0.12), y: Math.round(h * 0.1), width: Math.round(w * 0.76), height: Math.round(h * 0.2) } },
+    { id: 'subject-center', label: 'Main subject', bbox: { x: Math.round(w * 0.22), y: Math.round(h * 0.28), width: Math.round(w * 0.56), height: Math.round(h * 0.5) } },
+    { id: 'lower-detail', label: 'Lower detail', bbox: { x: Math.round(w * 0.18), y: Math.round(h * 0.72), width: Math.round(w * 0.64), height: Math.round(h * 0.18) } },
+  ];
+}
+
+export async function POST(request: Request) {
+  try {
+    const formData = await request.formData();
+    const image = formData.get('image');
+    const width = Number(formData.get('width'));
+    const height = Number(formData.get('height'));
+    if (!isFile(image)) return NextResponse.json({ error: 'image file is required' }, { status: 400 });
+    if (image.size > MAX_IMAGE_BYTES) return NextResponse.json({ error: 'image must be 20 MB or smaller' }, { status: 413 });
+    if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+      return NextResponse.json({ error: 'width and height are required' }, { status: 400 });
+    }
+
+    const sam3Segments = await runSam3Command(image);
+    return NextResponse.json({
+      success: true,
+      source: sam3Segments ? 'sam3' : 'fallback',
+      segments: sam3Segments ?? fallbackSegments(width, height),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Magic Layer segmentation failed';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/magic-layer/route.ts
+++ b/src/app/api/magic-layer/route.ts
@@ -4,8 +4,10 @@ import path from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { NextResponse } from 'next/server';
+import { resolveSam3Command, startInstallInBackground, isAutoInstallSupported } from '@/lib/magic-layer/runner';
 
 export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
 
 const execFileAsync = promisify(execFile);
 const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
@@ -43,19 +45,17 @@ function sanitizeSegments(value: unknown): SegmentResponse[] {
   });
 }
 
-async function runSam3Command(image: File): Promise<SegmentResponse[] | null> {
-  const command = process.env.BANANATAPE_SAM3_COMMAND?.trim();
-  if (!command) return null;
-
+async function runSam3Command(image: File, argv: string[]): Promise<SegmentResponse[] | null> {
+  if (!argv.length) return null;
   const dir = await mkdtemp(path.join(/*turbopackIgnore: true*/ tmpdir(), 'bananatape-sam3-'));
   const inputPath = path.join(dir, 'input.png');
   const outputPath = path.join(dir, 'segments.json');
   try {
     await writeFile(inputPath, Buffer.from(await image.arrayBuffer()));
-    const [bin, ...configuredArgs] = command.split(/\s+/);
+    const [bin, ...configuredArgs] = argv;
     const args = configuredArgs.map((arg) => arg.replaceAll('{input}', inputPath).replaceAll('{output}', outputPath));
-    if (!args.some((arg) => arg.includes(inputPath))) args.push(inputPath);
-    if (!args.some((arg) => arg.includes(outputPath))) args.push(outputPath);
+    if (!args.some((arg) => arg.includes(inputPath))) args.push('--input', inputPath);
+    if (!args.some((arg) => arg.includes(outputPath))) args.push('--output', outputPath);
     await execFileAsync(bin, args, { timeout: 120_000, maxBuffer: 10 * 1024 * 1024 });
     const parsed = JSON.parse(await readFile(outputPath, 'utf8'));
     const segments = sanitizeSegments(parsed);
@@ -88,12 +88,37 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'width and height are required' }, { status: 400 });
     }
 
-    const sam3Segments = await runSam3Command(image);
-    return NextResponse.json({
-      success: true,
-      source: sam3Segments ? 'sam3' : 'fallback',
-      segments: sam3Segments ?? fallbackSegments(width, height),
-    });
+    const resolved = await resolveSam3Command();
+
+    if (resolved.source === 'auto-mlx' && resolved.argv) {
+      const segments = await runSam3Command(image, resolved.argv);
+      return NextResponse.json({ success: true, source: 'sam3', segments: segments ?? fallbackSegments(width, height) });
+    }
+
+    if (resolved.source === 'env' && resolved.argv) {
+      const segments = await runSam3Command(image, resolved.argv);
+      return NextResponse.json({ success: true, source: 'sam3', segments: segments ?? fallbackSegments(width, height) });
+    }
+
+    if (isAutoInstallSupported()) {
+      const attempt = await startInstallInBackground();
+      if (attempt.status === 'started' || attempt.status === 'already-installing') {
+        return NextResponse.json(
+          { success: false, setupRequired: true, setupStatus: attempt.status, message: attempt.message },
+          { status: 202, headers: { 'Cache-Control': 'no-store' } },
+        );
+      }
+      if (attempt.status === 'missing-uv' || attempt.status === 'failed') {
+        return NextResponse.json({
+          success: true,
+          source: 'fallback',
+          segments: fallbackSegments(width, height),
+          setupHint: { errorCode: attempt.errorCode, message: attempt.message },
+        });
+      }
+    }
+
+    return NextResponse.json({ success: true, source: 'fallback', segments: fallbackSegments(width, height) });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Magic Layer segmentation failed';
     return NextResponse.json({ error: message }, { status: 500 });

--- a/src/app/api/magic-layer/status/route.ts
+++ b/src/app/api/magic-layer/status/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { readInstallStatus, isAutoInstallSupported } from '@/lib/magic-layer/runner';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  if (!isAutoInstallSupported()) {
+    return NextResponse.json(
+      { installed: false, installing: false, failed: false, autoInstallSupported: false, canFallback: true, message: 'Auto-install not supported on this platform.' },
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+  const status = await readInstallStatus();
+  return NextResponse.json(
+    { ...status, autoInstallSupported: true },
+    { headers: { 'Cache-Control': 'no-store' } },
+  );
+}

--- a/src/components/Canvas/CanvasImageItem.tsx
+++ b/src/components/Canvas/CanvasImageItem.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { EyeOff, Loader2, RefreshCw, X } from 'lucide-react';
+import { EyeOff, Loader2, RefreshCw, Wand2, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { CanvasContextMenu } from './CanvasContextMenu';
 import { useCanvasDrawingPerImage } from '@/hooks/useCanvasDrawingPerImage';
 import { useImageDrag } from '@/hooks/useImageDrag';
+import { hasMagicLayerChanges } from '@/lib/canvas/magic-layer-changes';
+import { useMagicLayerApply } from '@/hooks/useMagicLayerApply';
 import {
   ACTIVE_BOX_STROKE_WIDTH,
   createCanvasMapper,
@@ -153,6 +155,22 @@ function MagicLayerOverlay({ image, enabled }: { image: CanvasImage; enabled: bo
   const dragStartRef = useRef<{ layerId: string; pointerId: number; clientX: number; clientY: number; startX: number; startY: number } | null>(null);
   const layers = image.magicLayers ?? [];
 
+  const { apply } = useMagicLayerApply();
+  const [isApplying, setIsApplying] = useState(false);
+  const changesPending = hasMagicLayerChanges(image);
+  const canApply = enabled && changesPending && image.status === 'ready' && !isApplying;
+  const handleApply = useCallback(async (event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (!canApply) return;
+    setIsApplying(true);
+    try {
+      await apply(image.id);
+    } finally {
+      setIsApplying(false);
+    }
+  }, [apply, canApply, image.id]);
+
   const startDrag = useCallback((event: React.PointerEvent, layer: MagicLayer) => {
     if (!enabled || layer.hidden) return;
     event.preventDefault();
@@ -259,6 +277,33 @@ function MagicLayerOverlay({ image, enabled }: { image: CanvasImage; enabled: bo
           </div>
         );
       })}
+      {enabled && (changesPending || isApplying) && (
+        <button
+          type="button"
+          data-testid="magic-layer-apply"
+          aria-label="Apply Magic Layer changes"
+          disabled={!canApply}
+          onClick={handleApply}
+          className={cn(
+            'absolute right-11 top-2 z-50 flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-semibold shadow-xl ring-1 ring-fuchsia-300/40 backdrop-blur transition-all',
+            canApply
+              ? 'bg-fuchsia-600 text-white hover:bg-fuchsia-500 hover:shadow-fuchsia-500/30'
+              : 'bg-fuchsia-600/60 text-white/80 cursor-not-allowed opacity-60',
+          )}
+        >
+          {isApplying ? (
+            <>
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Applying…
+            </>
+          ) : (
+            <>
+              <Wand2 className="h-3.5 w-3.5" />
+              Apply
+            </>
+          )}
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/Canvas/CanvasImageItem.tsx
+++ b/src/components/Canvas/CanvasImageItem.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Loader2, RefreshCw, X } from 'lucide-react';
+import { EyeOff, Loader2, RefreshCw, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { CanvasContextMenu } from './CanvasContextMenu';
 import { useCanvasDrawingPerImage } from '@/hooks/useCanvasDrawingPerImage';
@@ -18,7 +18,7 @@ import {
 import { cn } from '@/lib/utils';
 import { useCanvasStore } from '@/stores/useCanvasStore';
 import { useEditorStore } from '@/stores/useEditorStore';
-import { DEFAULT_PLACEHOLDER_LAYOUT, type CanvasImage } from '@/types/canvas';
+import { DEFAULT_PLACEHOLDER_LAYOUT, type CanvasImage, type MagicLayer } from '@/types/canvas';
 
 interface CanvasImageItemProps {
   image: CanvasImage;
@@ -145,11 +145,130 @@ function ScopedMemoOverlay({ image, isFocused }: { image: CanvasImage; isFocused
   );
 }
 
+
+function MagicLayerOverlay({ image, enabled }: { image: CanvasImage; enabled: boolean }) {
+  const [draggingLayerId, setDraggingLayerId] = useState<string | null>(null);
+  const [livePositions, setLivePositions] = useState<Record<string, { x: number; y: number }>>({});
+  const livePositionsRef = useRef<Record<string, { x: number; y: number }>>({});
+  const dragStartRef = useRef<{ layerId: string; pointerId: number; clientX: number; clientY: number; startX: number; startY: number } | null>(null);
+  const layers = image.magicLayers ?? [];
+
+  const startDrag = useCallback((event: React.PointerEvent, layer: MagicLayer) => {
+    if (!enabled || layer.hidden) return;
+    event.preventDefault();
+    event.stopPropagation();
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId);
+    } catch {
+      // Pointer capture is unavailable in some test environments.
+    }
+    useCanvasStore.getState().selectMagicLayer(image.id, layer.id);
+    dragStartRef.current = {
+      layerId: layer.id,
+      pointerId: event.pointerId,
+      clientX: event.clientX,
+      clientY: event.clientY,
+      startX: layer.position.x,
+      startY: layer.position.y,
+    };
+    setDraggingLayerId(layer.id);
+  }, [enabled, image.id]);
+
+  const moveDrag = useCallback((event: React.PointerEvent) => {
+    const start = dragStartRef.current;
+    if (!start || event.pointerId !== start.pointerId) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const zoom = useCanvasStore.getState().viewport.zoom || 1;
+    const next = {
+      x: start.startX + (event.clientX - start.clientX) / zoom,
+      y: start.startY + (event.clientY - start.clientY) / zoom,
+    };
+    livePositionsRef.current = { ...livePositionsRef.current, [start.layerId]: next };
+    setLivePositions(livePositionsRef.current);
+  }, []);
+
+  const endDrag = useCallback((event: React.PointerEvent) => {
+    const start = dragStartRef.current;
+    if (!start || event.pointerId !== start.pointerId) return;
+    event.preventDefault();
+    event.stopPropagation();
+    try {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    } catch {
+      // See pointerdown.
+    }
+    const finalPosition = livePositionsRef.current[start.layerId];
+    if (finalPosition) {
+      useCanvasStore.getState().updateMagicLayer(image.id, start.layerId, { position: finalPosition });
+    }
+    dragStartRef.current = null;
+    setDraggingLayerId(null);
+    const nextLivePositions = { ...livePositionsRef.current };
+    delete nextLivePositions[start.layerId];
+    livePositionsRef.current = nextLivePositions;
+    setLivePositions(nextLivePositions);
+  }, [image.id]);
+
+  if (layers.length === 0) return null;
+
+  return (
+    <div className="absolute inset-0" data-testid="magic-layer-overlay" style={{ pointerEvents: enabled ? 'auto' : 'none' }}>
+      {layers.map((layer) => {
+        if (layer.hidden) return null;
+        const isSelected = image.selectedMagicLayerId === layer.id;
+        const position = livePositions[layer.id] ?? layer.position;
+        return (
+          <div
+            key={layer.id}
+            data-testid="magic-layer-item"
+            data-magic-layer-id={layer.id}
+            className={cn(
+              'group/magic absolute rounded-md',
+              isSelected ? 'ring-2 ring-fuchsia-400 ring-offset-2 ring-offset-transparent' : enabled ? 'hover:ring-2 hover:ring-white/80' : '',
+            )}
+            style={{
+              left: position.x,
+              top: position.y,
+              width: layer.sourceBounds.width,
+              height: layer.sourceBounds.height,
+              cursor: enabled ? (draggingLayerId === layer.id ? 'grabbing' : 'grab') : undefined,
+              touchAction: enabled ? 'none' : undefined,
+            }}
+            title={layer.name}
+            onPointerDown={(event) => startDrag(event, layer)}
+            onPointerMove={moveDrag}
+            onPointerUp={endDrag}
+            onPointerCancel={endDrag}
+          >
+            <img src={layer.cutoutDataUrl} alt={layer.name} className="block h-full w-full select-none object-contain" draggable={false} />
+            {enabled && isSelected && (
+              <button
+                type="button"
+                aria-label={`Hide ${layer.name}`}
+                className="absolute -right-2 -top-2 z-50 flex h-6 w-6 items-center justify-center rounded-full bg-fuchsia-600 text-white shadow-lg"
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  useCanvasStore.getState().hideMagicLayer(image.id, layer.id);
+                }}
+              >
+                <EyeOff className="h-3.5 w-3.5" />
+              </button>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 export function CanvasImageItem({ image, isFocused, isVisible, onFocus, onDelete, onRetry }: CanvasImageItemProps) {
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const size = getImageSize(image);
   const activeTool = useEditorStore((s) => s.activeTool);
   const moveEnabled = activeTool === 'move';
+  const magicLayerEnabled = activeTool === 'magic-layer' && isFocused;
   const drag = useImageDrag(image, { enabled: moveEnabled });
   const suppressClickRef = useRef(false);
 
@@ -231,8 +350,9 @@ export function CanvasImageItem({ image, isFocused, isVisible, onFocus, onDelete
 
       {isVisible && (image.status === 'ready' || image.status === 'streaming') && (
         <>
-          <img src={image.url} alt="Canvas base" className="block select-none" style={{ width: size.width, height: size.height, maxWidth: 'none', maxHeight: 'none' }} decoding="async" loading="lazy" draggable={false} />
-          {isFocused && <ScopedDrawingLayer image={image} />}
+          <img src={image.magicLayerBaseUrl ?? image.url} alt="Canvas base" className="block select-none" style={{ width: size.width, height: size.height, maxWidth: 'none', maxHeight: 'none' }} decoding="async" loading="lazy" draggable={false} />
+          <MagicLayerOverlay image={image} enabled={magicLayerEnabled} />
+          {isFocused && !magicLayerEnabled && <ScopedDrawingLayer image={image} />}
           <ScopedMemoOverlay image={image} isFocused={isFocused} />
         </>
       )}

--- a/src/components/Canvas/MagicLayerApplyButton.test.tsx
+++ b/src/components/Canvas/MagicLayerApplyButton.test.tsx
@@ -1,0 +1,192 @@
+/** @vitest-environment jsdom */
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  mockApply: vi.fn(),
+}));
+
+vi.mock('@/hooks/useMagicLayerApply', () => ({
+  useMagicLayerApply: () => ({ apply: mocks.mockApply }),
+}));
+
+import { CanvasImageItem } from './CanvasImageItem';
+import { useCanvasStore } from '@/stores/useCanvasStore';
+import { useEditorStore } from '@/stores/useEditorStore';
+import type { CanvasImage, MagicLayer } from '@/types/canvas';
+
+interface RenderResult {
+  host: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function renderItem(image: CanvasImage, isFocused: boolean): RenderResult {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  const root = createRoot(host);
+
+  act(() => {
+    root.render(
+      createElement(CanvasImageItem, {
+        image,
+        isFocused,
+        isVisible: true,
+        onFocus: () => {},
+        onDelete: () => {},
+        onRetry: () => {},
+      }),
+    );
+  });
+
+  return {
+    host,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      host.remove();
+    },
+  };
+}
+
+function makeLayer(overrides: Partial<MagicLayer> = {}): MagicLayer {
+  return {
+    id: 'layer-1',
+    name: 'Layer 1',
+    maskDataUrl: 'data:image/png;base64,mask',
+    cutoutDataUrl: 'data:image/png;base64,cutout',
+    sourceBounds: { x: 10, y: 20, width: 30, height: 40 },
+    position: { x: 100, y: 200 },
+    hidden: false,
+    ...overrides,
+  };
+}
+
+function makeImage(overrides: Partial<CanvasImage> = {}): CanvasImage {
+  return {
+    id: 'img-1',
+    url: 'data:image/png;base64,img',
+    size: { width: 300, height: 200 },
+    position: { x: 0, y: 0 },
+    parentId: null,
+    generationIndex: 0,
+    prompt: 'a red car',
+    provider: 'openai',
+    type: 'generate',
+    createdAt: 1,
+    paths: [],
+    boxes: [],
+    memos: [],
+    status: 'ready',
+    magicLayers: [makeLayer()],
+    magicLayerBaseUrl: 'data:image/png;base64,base',
+    ...overrides,
+  };
+}
+
+function queryApplyButton(host: HTMLElement): HTMLButtonElement | null {
+  return host.querySelector('[data-testid="magic-layer-apply"]');
+}
+
+beforeEach(() => {
+  useCanvasStore.getState().resetCanvas();
+  useEditorStore.getState().setActiveTool('magic-layer');
+  mocks.mockApply.mockReset();
+  mocks.mockApply.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  useCanvasStore.getState().resetCanvas();
+  useEditorStore.getState().setActiveTool('pan');
+});
+
+describe('MagicLayerOverlay Apply button', () => {
+  it('does not render when the active tool is not magic-layer', () => {
+    useEditorStore.getState().setActiveTool('pan');
+    const image = makeImage();
+    const { host, unmount } = renderItem(image, true);
+
+    expect(queryApplyButton(host)).toBeNull();
+
+    unmount();
+  });
+
+  it('does not render when the image is not focused', () => {
+    useEditorStore.getState().setActiveTool('magic-layer');
+    const image = makeImage();
+    const { host, unmount } = renderItem(image, false);
+
+    expect(queryApplyButton(host)).toBeNull();
+
+    unmount();
+  });
+
+  it('does not render when the image has no magic layers', () => {
+    useEditorStore.getState().setActiveTool('magic-layer');
+    const image = makeImage({ magicLayers: undefined });
+    const { host, unmount } = renderItem(image, true);
+
+    expect(queryApplyButton(host)).toBeNull();
+
+    unmount();
+  });
+
+  it('does not render when no magic-layer changes are pending', () => {
+    useEditorStore.getState().setActiveTool('magic-layer');
+    const layer = makeLayer({
+      sourceBounds: { x: 10, y: 20, width: 30, height: 40 },
+      position: { x: 10, y: 20 },
+      hidden: false,
+    });
+    const image = makeImage({ magicLayers: [layer] });
+    const { host, unmount } = renderItem(image, true);
+
+    expect(queryApplyButton(host)).toBeNull();
+
+    unmount();
+  });
+
+  it('renders enabled when there are uncommitted magic-layer changes', () => {
+    useEditorStore.getState().setActiveTool('magic-layer');
+    const image = makeImage();
+    const { host, unmount } = renderItem(image, true);
+
+    const button = queryApplyButton(host);
+    expect(button).not.toBeNull();
+    expect(button?.disabled).toBe(false);
+
+    unmount();
+  });
+
+  it('is disabled when the image status is not "ready"', () => {
+    useEditorStore.getState().setActiveTool('magic-layer');
+    const image = makeImage({ status: 'streaming' });
+    const { host, unmount } = renderItem(image, true);
+
+    const button = queryApplyButton(host);
+    expect(button).not.toBeNull();
+    expect(button?.disabled).toBe(true);
+
+    unmount();
+  });
+
+  it('calls apply with the image id when the enabled button is clicked', async () => {
+    useEditorStore.getState().setActiveTool('magic-layer');
+    const image = makeImage();
+    const { host, unmount } = renderItem(image, true);
+
+    const button = queryApplyButton(host);
+    expect(button).not.toBeNull();
+
+    await act(async () => {
+      button!.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+
+    expect(mocks.mockApply).toHaveBeenCalledTimes(1);
+    expect(mocks.mockApply).toHaveBeenCalledWith('img-1');
+
+    unmount();
+  });
+});

--- a/src/components/Composer/BottomComposer.tsx
+++ b/src/components/Composer/BottomComposer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef } from 'react';
-import { ImagePlus, Loader2, Minus, Plus, Wand2, Pencil, X, Undo2, Redo2 } from 'lucide-react';
+import { ImagePlus, Loader2, Minus, Plus, Wand2, Pencil, X, Undo2, Redo2, Sparkles } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
@@ -13,6 +13,7 @@ import { cn } from '@/lib/utils';
 import { countFocusedAnnotations, hasBusyFocusedBranches, isEditableGenerationSource } from '@/lib/generation/branch-busy';
 import type { Provider } from '@/types';
 import type { ReferenceImagePreview } from '@/components/Composer/types';
+import { useMagicLayers } from '@/hooks/useMagicLayers';
 
 function formatProviderLabel(provider: Provider) {
   return provider === 'god-tibo' ? 'codex' : 'OpenAI';
@@ -59,6 +60,7 @@ export function BottomComposer({
   const parallelCount = useEditorStore((s) => s.parallelCount);
   const incrementParallelCount = useEditorStore((s) => s.incrementParallelCount);
   const decrementParallelCount = useEditorStore((s) => s.decrementParallelCount);
+  const { activateMagicLayer, canActivateMagicLayer, isSegmenting } = useMagicLayers();
 
   const annotationCount = paths.length + boxes.length + memos.filter((memo) => memo.text.trim()).length + focusedAnnotationCount;
   const canEdit = !!baseImage || focusedReadyImageCount > 0;
@@ -110,6 +112,18 @@ export function BottomComposer({
               </Select>
             </div>
             <div className="flex items-center gap-1 rounded-xl border border-white/10 bg-[#1e1e1e] p-1">
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                className="h-8 gap-1 px-2 text-xs text-[#b3b3b3] hover:bg-white/10 hover:text-white"
+                disabled={!canActivateMagicLayer || isSegmenting}
+                onClick={() => void activateMagicLayer()}
+                title="Segment selected image into draggable Magic Layers"
+              >
+                {isSegmenting ? <Loader2 className="h-3 w-3 animate-spin" /> : <Sparkles className="h-3 w-3" />}
+                Magic Layer
+              </Button>
               <Button type="button" size="icon-xs" variant="ghost" className="text-[#b3b3b3] hover:bg-white/10 hover:text-white" onClick={undo} disabled={!canUndo} aria-label="Undo" title={focusedImageIds.length === 1 ? "Undo selected image (Cmd/Ctrl+Z)" : "Select one image to undo"}>
                 <Undo2 className="h-3 w-3" />
               </Button>

--- a/src/components/Composer/BottomComposer.tsx
+++ b/src/components/Composer/BottomComposer.tsx
@@ -60,7 +60,7 @@ export function BottomComposer({
   const parallelCount = useEditorStore((s) => s.parallelCount);
   const incrementParallelCount = useEditorStore((s) => s.incrementParallelCount);
   const decrementParallelCount = useEditorStore((s) => s.decrementParallelCount);
-  const { activateMagicLayer, canActivateMagicLayer, isSegmenting } = useMagicLayers();
+  const { activateMagicLayer, canActivateMagicLayer, isSegmenting, isPreparing, isBusy } = useMagicLayers();
 
   const annotationCount = paths.length + boxes.length + memos.filter((memo) => memo.text.trim()).length + focusedAnnotationCount;
   const canEdit = !!baseImage || focusedReadyImageCount > 0;
@@ -117,12 +117,13 @@ export function BottomComposer({
                 size="sm"
                 variant="ghost"
                 className="h-8 gap-1 px-2 text-xs text-[#b3b3b3] hover:bg-white/10 hover:text-white"
-                disabled={!canActivateMagicLayer || isSegmenting}
+                disabled={!canActivateMagicLayer || isBusy}
                 onClick={() => void activateMagicLayer()}
-                title="Segment selected image into draggable Magic Layers"
+                title={isPreparing ? 'First-time setup: downloading AI model (~3–4 GB)…' : 'Segment selected image into draggable Magic Layers'}
+                data-state={isPreparing ? 'preparing' : isSegmenting ? 'segmenting' : 'idle'}
               >
-                {isSegmenting ? <Loader2 className="h-3 w-3 animate-spin" /> : <Sparkles className="h-3 w-3" />}
-                Magic Layer
+                {isBusy ? <Loader2 className="h-3 w-3 animate-spin" /> : <Sparkles className="h-3 w-3" />}
+                {isPreparing ? 'Preparing AI…' : 'Magic Layer'}
               </Button>
               <Button type="button" size="icon-xs" variant="ghost" className="text-[#b3b3b3] hover:bg-white/10 hover:text-white" onClick={undo} disabled={!canUndo} aria-label="Undo" title={focusedImageIds.length === 1 ? "Undo selected image (Cmd/Ctrl+Z)" : "Select one image to undo"}>
                 <Undo2 className="h-3 w-3" />

--- a/src/components/EditorLayout.tsx
+++ b/src/components/EditorLayout.tsx
@@ -52,19 +52,44 @@ function StandaloneEditorShell() {
         if (!historyRes.ok) return;
         const history = await historyRes.json();
         if (cancelled || !Array.isArray(history.entries)) return;
-        hydrateEntries(history.entries.map((entry: { assetUrl?: string; imageDataUrl?: string }) => ({
-          ...entry,
-          imageDataUrl: entry.imageDataUrl ?? entry.assetUrl,
-        })));
         const first = history.entries[0];
-        if (first?.assetUrl) setBaseImage(first.assetUrl, { width: 0, height: 0 });
+        const rootImageId = typeof first?.imageId === 'string' ? first.imageId : (typeof first?.id === 'string' ? first.id : null);
+        const entries = history.entries.map((entry: { id?: string; imageId?: string; assetUrl?: string; imageDataUrl?: string }) => ({
+          ...entry,
+          imageId: entry.imageId ?? rootImageId ?? undefined,
+          imageDataUrl: entry.imageDataUrl ?? entry.assetUrl,
+        }));
+        hydrateEntries(entries);
+        if (first?.assetUrl) {
+          setBaseImage(first.assetUrl, { width: 0, height: 0 });
+          if (rootImageId && canvasImageCount === 0) {
+            const rootImage: CanvasImage = {
+              id: rootImageId,
+              url: first.assetUrl,
+              assetId: typeof first.assetId === 'string' ? first.assetId : undefined,
+              size: { width: 1024, height: 1024 },
+              position: { x: 0, y: 0 },
+              parentId: null,
+              generationIndex: 0,
+              prompt: typeof first.prompt === 'string' ? first.prompt : '',
+              provider: first.provider === 'god-tibo' ? 'god-tibo' : 'openai',
+              type: first.type === 'edit' ? 'edit' : 'generate',
+              createdAt: typeof first.timestamp === 'number' ? first.timestamp : Date.now(),
+              paths: [],
+              boxes: [],
+              memos: [],
+              status: 'ready',
+            };
+            hydrateCanvas({ [rootImageId]: rootImage }, [rootImageId], [rootImageId]);
+          }
+        }
       } catch {
         // No active local project; keep no-project fallback behavior.
       }
     }
     void hydrateProjectHistory();
     return () => { cancelled = true; };
-  }, [hydrateEntries, setBaseImage]);
+  }, [canvasImageCount, hydrateCanvas, hydrateEntries, setBaseImage]);
 
   useEffect(() => {
     if (!baseImage || canvasImageCount > 0) return;

--- a/src/components/Toolbar/ToolPalette.tsx
+++ b/src/components/Toolbar/ToolPalette.tsx
@@ -3,7 +3,7 @@
 import { useEditorStore } from '@/stores/useEditorStore';
 import { useCanvasStore } from '@/stores/useCanvasStore';
 import { Button } from '@/components/ui/button';
-import { ArrowUpRight, Hand, MousePointer2, Pen, Square, StickyNote, Trash2 } from 'lucide-react';
+import { ArrowUpRight, Hand, Layers3, MousePointer2, Pen, Square, StickyNote, Trash2 } from 'lucide-react';
 
 const tools = [
   { id: 'pan' as const, icon: Hand, label: 'Pan', shortcut: '1' },
@@ -12,6 +12,7 @@ const tools = [
   { id: 'arrow' as const, icon: ArrowUpRight, label: 'Arrow', shortcut: '4' },
   { id: 'memo' as const, icon: StickyNote, label: 'Sticky memo', shortcut: '5' },
   { id: 'move' as const, icon: MousePointer2, label: 'Move image', shortcut: '6' },
+  { id: 'magic-layer' as const, icon: Layers3, label: 'Magic Layer', shortcut: '7' },
 ];
 
 export function ToolPalette() {

--- a/src/hooks/useCanvasExport.ts
+++ b/src/hooks/useCanvasExport.ts
@@ -15,6 +15,16 @@ function canvasToBlob(canvas: HTMLCanvasElement, type = 'image/png'): Promise<Bl
   });
 }
 
+function loadImageFromUrl(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+    img.src = url;
+  });
+}
+
 function loadImageFromDataUrl(url: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const img = new Image();
@@ -107,6 +117,28 @@ export function useCanvasExport() {
       memos: image.memos,
       naturalSize,
     });
+    const magicLayers = image.magicLayers ?? [];
+    const hasMagicLayers = Boolean(image.magicLayerBaseUrl && magicLayers.length > 0);
+    let magicComposite: Blob | null = null;
+    if (hasMagicLayers) {
+      const magicBaseImage = await loadImageFromUrl(image.magicLayerBaseUrl!);
+      const magicCanvas = overlayAnnotations({
+        baseImage: magicBaseImage,
+        paths: image.paths,
+        boxes: image.boxes,
+        memos: image.memos,
+        naturalSize,
+      });
+      const magicCtx = magicCanvas.getContext('2d');
+      if (magicCtx) {
+        for (const layer of magicLayers) {
+          if (layer.hidden) continue;
+          const layerImage = await loadImageFromUrl(layer.cutoutDataUrl);
+          magicCtx.drawImage(layerImage, layer.position.x, layer.position.y, layer.sourceBounds.width, layer.sourceBounds.height);
+        }
+      }
+      magicComposite = await canvasToBlob(magicCanvas);
+    }
     const maskCanvas = generateMask({
       paths: image.paths,
       boxes: image.boxes,
@@ -114,8 +146,8 @@ export function useCanvasExport() {
     });
 
     return {
-      original,
-      annotated: await canvasToBlob(annotatedCanvas),
+      original: magicComposite ?? original,
+      annotated: magicComposite ?? await canvasToBlob(annotatedCanvas),
       mask: await canvasToBlob(maskCanvas),
       size: naturalSize,
     };

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -54,6 +54,15 @@ export function useKeyboardShortcuts() {
 
       if (e.key === 'Delete' || e.key === 'Backspace') {
         const canvasState = useCanvasStore.getState();
+        if (state.activeTool === 'magic-layer' && canvasState.focusedImageIds.length === 1) {
+          const imageId = canvasState.focusedImageIds[0];
+          const selectedLayerId = canvasState.images[imageId]?.selectedMagicLayerId;
+          if (selectedLayerId) {
+            e.preventDefault();
+            canvasState.hideMagicLayer(imageId, selectedLayerId);
+            return;
+          }
+        }
         if (canvasState.focusedImageIds.length > 0) {
           e.preventDefault();
           const count = canvasState.focusedImageIds.length;
@@ -96,6 +105,12 @@ export function useKeyboardShortcuts() {
       if (e.key === '6') {
         e.preventDefault();
         state.setActiveTool('move');
+        return;
+      }
+
+      if (e.key === '7') {
+        e.preventDefault();
+        state.setActiveTool('magic-layer');
         return;
       }
 

--- a/src/hooks/useMagicLayerApply.test.ts
+++ b/src/hooks/useMagicLayerApply.test.ts
@@ -1,0 +1,271 @@
+/** @vitest-environment jsdom */
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCanvasStore } from '@/stores/useCanvasStore';
+import { useEditorStore } from '@/stores/useEditorStore';
+import {
+  MAGIC_LAYER_INPAINT_INSTRUCTION,
+  composeMagicLayerPrompt,
+} from '@/lib/prompt/magic-layer-inpaint';
+import type { CanvasImage, MagicLayer } from '@/types/canvas';
+
+const mocks = vi.hoisted(() => ({
+  mockGenerate: vi.fn(),
+  mockAddToast: vi.fn(),
+}));
+
+vi.mock('@/hooks/useParallelGenerate', () => ({
+  useParallelGenerate: () => ({
+    generate: mocks.mockGenerate,
+    cancel: vi.fn(),
+    cancelAll: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/Composer/PromptComposerProvider', () => {
+  const file = new File(['x'], 'r.png', { type: 'image/png' });
+  const referenceImages = [{ id: 'r1', file, previewUrl: 'blob:r' }];
+  return {
+    usePromptComposer: () => ({
+      systemPrompt: 'SYS',
+      designContext: 'DC',
+      referenceImages,
+    }),
+  };
+});
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ addToast: mocks.mockAddToast }),
+}));
+
+import { useMagicLayerApply, type UseMagicLayerApplyApi } from './useMagicLayerApply';
+
+interface GenerateCallArgs {
+  count: number;
+  prompt: string;
+  systemPrompt?: string;
+  designContext?: string;
+  referenceImages?: { file: File; id: string }[];
+  parentIds?: string[];
+  outputSize?: string;
+}
+
+function getGenerateCall(index = 0): GenerateCallArgs {
+  const args = mocks.mockGenerate.mock.calls[index];
+  if (!args) throw new Error(`generate was not called (index ${index})`);
+  return args[0] as GenerateCallArgs;
+}
+
+function makeLayer(overrides: Partial<MagicLayer> = {}): MagicLayer {
+  return {
+    id: 'layer-1',
+    name: 'Layer 1',
+    maskDataUrl: 'data:image/png;base64,mask',
+    cutoutDataUrl: 'data:image/png;base64,cutout',
+    sourceBounds: { x: 10, y: 20, width: 30, height: 40 },
+    position: { x: 100, y: 200 },
+    hidden: false,
+    ...overrides,
+  };
+}
+
+function seedImage(overrides: Partial<CanvasImage> = {}): CanvasImage {
+  const image: CanvasImage = {
+    id: 'img-1',
+    url: 'data:image/png;base64,img',
+    size: { width: 300, height: 200 },
+    position: { x: 0, y: 0 },
+    parentId: null,
+    generationIndex: 0,
+    prompt: 'a red car',
+    provider: 'openai',
+    type: 'generate',
+    createdAt: 1,
+    paths: [],
+    boxes: [],
+    memos: [],
+    status: 'ready',
+    magicLayers: [makeLayer()],
+    magicLayerBaseUrl: 'data:image/png;base64,base',
+    ...overrides,
+  };
+  useCanvasStore.setState((state) => ({
+    images: { ...state.images, [image.id]: image },
+    imageOrder: state.imageOrder.includes(image.id)
+      ? state.imageOrder
+      : [...state.imageOrder, image.id],
+  }));
+  return image;
+}
+
+function renderUseMagicLayerApply(): { current: UseMagicLayerApplyApi; unmount: () => void } {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  const root: Root = createRoot(host);
+  const result: { current?: UseMagicLayerApplyApi } = {};
+
+  function TestComponent() {
+    result.current = useMagicLayerApply();
+    return null;
+  }
+
+  act(() => {
+    root.render(createElement(TestComponent));
+  });
+
+  if (!result.current) {
+    throw new Error('Hook did not render');
+  }
+
+  return {
+    current: result.current,
+    unmount: () => {
+      act(() => root.unmount());
+      host.remove();
+    },
+  };
+}
+
+beforeEach(() => {
+  useCanvasStore.getState().resetCanvas();
+  useEditorStore.getState().setParallelCount(1);
+  useEditorStore.getState().setOutputSize('auto');
+  mocks.mockGenerate.mockReset();
+  mocks.mockGenerate.mockResolvedValue(undefined);
+  mocks.mockAddToast.mockReset();
+});
+
+describe('useMagicLayerApply', () => {
+  it('composes the prompt by appending the inpaint instruction to the original prompt', async () => {
+    seedImage({ prompt: 'a red car' });
+    const { current, unmount } = renderUseMagicLayerApply();
+
+    await act(async () => {
+      await current.apply('img-1');
+    });
+
+    expect(mocks.mockGenerate).toHaveBeenCalledTimes(1);
+    const call = getGenerateCall();
+    expect(call.prompt).toBe(composeMagicLayerPrompt('a red car'));
+    expect(call.systemPrompt).toBe('SYS');
+    expect(call.designContext).toBe('DC');
+    expect(call.referenceImages).toHaveLength(1);
+    expect(call.referenceImages?.[0].id).toBe('r1');
+    expect(call.parentIds).toEqual(['img-1']);
+
+    unmount();
+  });
+
+  it('falls back to the inpaint instruction only when the original prompt is empty', async () => {
+    seedImage({ prompt: '' });
+    const { current, unmount } = renderUseMagicLayerApply();
+
+    await act(async () => {
+      await current.apply('img-1');
+    });
+
+    expect(mocks.mockGenerate).toHaveBeenCalledTimes(1);
+    expect(getGenerateCall().prompt).toBe(MAGIC_LAYER_INPAINT_INSTRUCTION);
+
+    unmount();
+  });
+
+  it('does not call generate when no magic layers have moved or are hidden', async () => {
+    seedImage({
+      magicLayers: [
+        makeLayer({ position: { x: 10, y: 20 }, hidden: false }),
+        makeLayer({ id: 'layer-2', position: { x: 10, y: 20 }, hidden: false }),
+      ],
+    });
+    const { current, unmount } = renderUseMagicLayerApply();
+
+    await act(async () => {
+      await current.apply('img-1');
+    });
+
+    expect(mocks.mockGenerate).not.toHaveBeenCalled();
+    expect(mocks.mockAddToast).toHaveBeenCalledWith(
+      'Move or hide a Magic Layer before applying',
+      'info',
+    );
+
+    unmount();
+  });
+
+  it('does not call generate when the image id does not exist', async () => {
+    const { current, unmount } = renderUseMagicLayerApply();
+
+    await act(async () => {
+      await current.apply('nonexistent');
+    });
+
+    expect(mocks.mockGenerate).not.toHaveBeenCalled();
+    expect(mocks.mockAddToast).toHaveBeenCalledWith('Image not found', 'error');
+
+    unmount();
+  });
+
+  it('does not call generate when the source image is still pending', async () => {
+    seedImage({ status: 'pending' });
+    const { current, unmount } = renderUseMagicLayerApply();
+
+    await act(async () => {
+      await current.apply('img-1');
+    });
+
+    expect(mocks.mockGenerate).not.toHaveBeenCalled();
+    expect(mocks.mockAddToast).toHaveBeenCalledWith('Image is still generating', 'info');
+
+    unmount();
+  });
+
+  it('clears selectedMagicLayerId once the apply succeeds', async () => {
+    seedImage({ selectedMagicLayerId: 'layer-1' });
+    const { current, unmount } = renderUseMagicLayerApply();
+
+    await act(async () => {
+      await current.apply('img-1');
+    });
+
+    expect(mocks.mockGenerate).toHaveBeenCalledTimes(1);
+    expect(useCanvasStore.getState().images['img-1']?.selectedMagicLayerId).toBeNull();
+    expect(mocks.mockAddToast).toHaveBeenCalledWith('Magic Layer applied', 'success');
+
+    unmount();
+  });
+
+  it('surfaces generate failures via the toast and keeps selectedMagicLayerId untouched', async () => {
+    seedImage({ selectedMagicLayerId: 'layer-1' });
+    mocks.mockGenerate.mockReset();
+    mocks.mockGenerate.mockRejectedValue(new Error('boom'));
+    const { current, unmount } = renderUseMagicLayerApply();
+
+    await act(async () => {
+      await current.apply('img-1');
+    });
+
+    expect(mocks.mockAddToast).toHaveBeenCalledWith('boom', 'error');
+    expect(useCanvasStore.getState().images['img-1']?.selectedMagicLayerId).toBe('layer-1');
+
+    unmount();
+  });
+
+  it('forwards parallelCount and outputSize from the editor store', async () => {
+    seedImage();
+    useEditorStore.getState().setParallelCount(3);
+    useEditorStore.getState().setOutputSize('1024x1024');
+    const { current, unmount } = renderUseMagicLayerApply();
+
+    await act(async () => {
+      await current.apply('img-1');
+    });
+
+    const call = getGenerateCall();
+    expect(call.count).toBe(3);
+    expect(call.outputSize).toBe('1024x1024');
+
+    unmount();
+  });
+});

--- a/src/hooks/useMagicLayerApply.ts
+++ b/src/hooks/useMagicLayerApply.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import { useCallback } from 'react';
+import { useCanvasStore } from '@/stores/useCanvasStore';
+import { useEditorStore } from '@/stores/useEditorStore';
+import { useParallelGenerate } from '@/hooks/useParallelGenerate';
+import { usePromptComposer } from '@/components/Composer/PromptComposerProvider';
+import { useToast } from '@/hooks/useToast';
+import { composeMagicLayerPrompt } from '@/lib/prompt/magic-layer-inpaint';
+import { hasMagicLayerChanges } from '@/lib/canvas/magic-layer-changes';
+
+export interface UseMagicLayerApplyApi {
+  apply: (imageId: string) => Promise<void>;
+}
+
+export function useMagicLayerApply(): UseMagicLayerApplyApi {
+  const parallelGenerate = useParallelGenerate();
+  const { systemPrompt, designContext, referenceImages } = usePromptComposer();
+  const { addToast } = useToast();
+
+  const apply = useCallback(async (imageId: string): Promise<void> => {
+    const image = useCanvasStore.getState().images[imageId];
+    if (!image) {
+      addToast('Image not found', 'error');
+      return;
+    }
+
+    if (!hasMagicLayerChanges(image)) {
+      addToast('Move or hide a Magic Layer before applying', 'info');
+      return;
+    }
+
+    if (image.status === 'pending' || image.status === 'streaming') {
+      addToast('Image is still generating', 'info');
+      return;
+    }
+
+    const composedPrompt = composeMagicLayerPrompt(image.prompt);
+    const { parallelCount, outputSize } = useEditorStore.getState();
+
+    try {
+      await parallelGenerate.generate({
+        count: parallelCount,
+        prompt: composedPrompt,
+        systemPrompt,
+        designContext,
+        referenceImages: referenceImages.map((r) => ({ file: r.file, id: r.id })),
+        parentIds: [imageId],
+        outputSize,
+      });
+      useCanvasStore.getState().selectMagicLayer(imageId, null);
+      addToast('Magic Layer applied', 'success');
+    } catch (error) {
+      addToast(error instanceof Error ? error.message : 'Apply failed', 'error');
+    }
+  }, [parallelGenerate, systemPrompt, designContext, referenceImages, addToast]);
+
+  return { apply };
+}

--- a/src/hooks/useMagicLayers.ts
+++ b/src/hooks/useMagicLayers.ts
@@ -17,6 +17,43 @@ interface MagicLayerApiResponse {
   source?: 'sam3' | 'fallback';
   segments?: MagicLayerSegment[];
   error?: string;
+  setupRequired?: boolean;
+  setupStatus?: string;
+  message?: string;
+  setupHint?: { errorCode?: string; message?: string };
+}
+
+interface MagicLayerStatusResponse {
+  installed: boolean;
+  installing: boolean;
+  failed: boolean;
+  autoInstallSupported: boolean;
+  message?: string;
+  canFallback?: boolean;
+}
+
+const SETUP_POLL_INTERVAL_MS = 4000;
+const SETUP_POLL_MAX_ATTEMPTS = 600;
+
+async function waitForSetup(imageId: string): Promise<'ready' | 'failed' | 'unsupported'> {
+  const store = useCanvasStore.getState();
+  for (let attempt = 0; attempt < SETUP_POLL_MAX_ATTEMPTS; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, SETUP_POLL_INTERVAL_MS));
+    let payload: MagicLayerStatusResponse;
+    try {
+      const res = await fetch('/api/magic-layer/status', { cache: 'no-store' });
+      payload = await res.json() as MagicLayerStatusResponse;
+    } catch {
+      continue;
+    }
+    if (!payload.autoInstallSupported) return 'unsupported';
+    if (payload.failed) return 'failed';
+    if (payload.installed) return 'ready';
+    if (payload.message) {
+      store.setMagicLayerStatus(imageId, 'preparing', payload.message);
+    }
+  }
+  return 'failed';
 }
 
 export function useMagicLayers() {
@@ -24,7 +61,9 @@ export function useMagicLayers() {
   const focusedImage = useCanvasStore((s) => s.focusedImageIds.length === 1 ? s.images[s.focusedImageIds[0]] : undefined);
 
   const canActivateMagicLayer = Boolean(focusedImage && focusedImage.status === 'ready' && focusedImage.size.width > 0 && focusedImage.size.height > 0);
+  const isPreparing = focusedImage?.magicLayerStatus === 'preparing';
   const isSegmenting = focusedImage?.magicLayerStatus === 'segmenting';
+  const isBusy = isPreparing || isSegmenting;
 
   const activateMagicLayer = useCallback(async () => {
     const imageId = focusedImageIds.length === 1 ? focusedImageIds[0] : null;
@@ -35,13 +74,29 @@ export function useMagicLayers() {
     const store = useCanvasStore.getState();
     store.setMagicLayerStatus(imageId, 'segmenting');
     try {
-      const file = await imageUrlToFile(image.url);
-      const formData = new FormData();
+      let file = await imageUrlToFile(image.url);
+      let formData = new FormData();
       formData.set('image', file);
       formData.set('width', String(image.size.width));
       formData.set('height', String(image.size.height));
 
-      const response = await fetch('/api/magic-layer', { method: 'POST', body: formData });
+      let response = await fetch('/api/magic-layer', { method: 'POST', body: formData });
+
+      if (response.status === 202) {
+        const setupPayload = await response.json() as MagicLayerApiResponse;
+        store.setMagicLayerStatus(imageId, 'preparing', setupPayload.message ?? 'Preparing AI model for first-time use…');
+        const outcome = await waitForSetup(imageId);
+        if (outcome === 'failed') throw new Error('Magic Layer setup failed. See server logs for details.');
+        if (outcome === 'unsupported') throw new Error('Auto-install not supported on this platform.');
+        store.setMagicLayerStatus(imageId, 'segmenting');
+        file = await imageUrlToFile(image.url);
+        formData = new FormData();
+        formData.set('image', file);
+        formData.set('width', String(image.size.width));
+        formData.set('height', String(image.size.height));
+        response = await fetch('/api/magic-layer', { method: 'POST', body: formData });
+      }
+
       const payload = await response.json() as MagicLayerApiResponse;
       if (!response.ok || !payload.segments?.length) {
         throw new Error(payload.error || 'Magic Layer did not find movable elements');
@@ -61,5 +116,5 @@ export function useMagicLayers() {
     }
   }, [focusedImageIds]);
 
-  return { activateMagicLayer, canActivateMagicLayer, isSegmenting };
+  return { activateMagicLayer, canActivateMagicLayer, isSegmenting, isPreparing, isBusy };
 }

--- a/src/hooks/useMagicLayers.ts
+++ b/src/hooks/useMagicLayers.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useCallback } from 'react';
+import { buildMagicLayerComposite, type MagicLayerSegment } from '@/lib/canvas/magic-layer';
+import { useCanvasStore } from '@/stores/useCanvasStore';
+import { useEditorStore } from '@/stores/useEditorStore';
+
+async function imageUrlToFile(url: string): Promise<File> {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error('Unable to read selected image pixels');
+  const blob = await response.blob();
+  return new File([blob], 'magic-layer-source.png', { type: blob.type || 'image/png' });
+}
+
+interface MagicLayerApiResponse {
+  success?: boolean;
+  source?: 'sam3' | 'fallback';
+  segments?: MagicLayerSegment[];
+  error?: string;
+}
+
+export function useMagicLayers() {
+  const focusedImageIds = useCanvasStore((s) => s.focusedImageIds);
+  const focusedImage = useCanvasStore((s) => s.focusedImageIds.length === 1 ? s.images[s.focusedImageIds[0]] : undefined);
+
+  const canActivateMagicLayer = Boolean(focusedImage && focusedImage.status === 'ready' && focusedImage.size.width > 0 && focusedImage.size.height > 0);
+  const isSegmenting = focusedImage?.magicLayerStatus === 'segmenting';
+
+  const activateMagicLayer = useCallback(async () => {
+    const imageId = focusedImageIds.length === 1 ? focusedImageIds[0] : null;
+    if (!imageId) return;
+    const image = useCanvasStore.getState().images[imageId];
+    if (!image || image.status !== 'ready') return;
+
+    const store = useCanvasStore.getState();
+    store.setMagicLayerStatus(imageId, 'segmenting');
+    try {
+      const file = await imageUrlToFile(image.url);
+      const formData = new FormData();
+      formData.set('image', file);
+      formData.set('width', String(image.size.width));
+      formData.set('height', String(image.size.height));
+
+      const response = await fetch('/api/magic-layer', { method: 'POST', body: formData });
+      const payload = await response.json() as MagicLayerApiResponse;
+      if (!response.ok || !payload.segments?.length) {
+        throw new Error(payload.error || 'Magic Layer did not find movable elements');
+      }
+
+      const composite = await buildMagicLayerComposite({
+        imageUrl: image.url,
+        imageSize: image.size,
+        segments: payload.segments,
+      });
+      if (composite.layers.length === 0) throw new Error('Magic Layer did not create any cutouts');
+      useCanvasStore.getState().setMagicLayers(imageId, composite.layers, composite.baseUrl);
+      useEditorStore.getState().setActiveTool('magic-layer');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Magic Layer failed';
+      useCanvasStore.getState().setMagicLayerStatus(imageId, 'error', message);
+    }
+  }, [focusedImageIds]);
+
+  return { activateMagicLayer, canActivateMagicLayer, isSegmenting };
+}

--- a/src/hooks/useParallelGenerate.ts
+++ b/src/hooks/useParallelGenerate.ts
@@ -275,7 +275,7 @@ export function useParallelGenerate(): UseParallelGenerateApi {
           assetId: data.assetId,
           status: 'ready',
         }, { track: false });
-        if (useCanvasStore.getState().focusedImageIds.length === 0) {
+        if (placeholder.parentId || useCanvasStore.getState().focusedImageIds.length === 0) {
           useCanvasStore.getState().setFocusedImage(placeholder.id);
         }
         useHistoryStore.getState().addEntry({

--- a/src/lib/canvas/magic-layer-changes.test.ts
+++ b/src/lib/canvas/magic-layer-changes.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { hasMagicLayerChanges, isLayerMoved } from './magic-layer-changes';
+import type { CanvasImage, MagicLayer } from '@/types/canvas';
+
+function layer(overrides: Partial<MagicLayer> = {}): MagicLayer {
+  return {
+    id: 'layer-1',
+    name: 'Layer 1',
+    maskDataUrl: 'data:image/png;base64,mask',
+    cutoutDataUrl: 'data:image/png;base64,cutout',
+    sourceBounds: { x: 10, y: 20, width: 30, height: 40 },
+    position: { x: 10, y: 20 },
+    hidden: false,
+    ...overrides,
+  };
+}
+
+function image(magicLayers?: CanvasImage['magicLayers']): Pick<CanvasImage, 'magicLayers'> {
+  return { magicLayers };
+}
+
+describe('magic-layer-changes', () => {
+  it('returns false when magicLayers is undefined', () => {
+    expect(hasMagicLayerChanges(image(undefined))).toBe(false);
+  });
+
+  it('returns false when magicLayers is empty', () => {
+    expect(hasMagicLayerChanges(image([]))).toBe(false);
+  });
+
+  it('returns false for a single untouched visible layer', () => {
+    expect(hasMagicLayerChanges(image([layer()]))).toBe(false);
+  });
+
+  it('returns true for a single moved layer when x differs', () => {
+    expect(hasMagicLayerChanges(image([layer({ position: { x: 11, y: 20 } })]))).toBe(true);
+  });
+
+  it('returns true for a single moved layer when y differs', () => {
+    expect(hasMagicLayerChanges(image([layer({ position: { x: 10, y: 21 } })]))).toBe(true);
+  });
+
+  it('returns true for a single hidden layer', () => {
+    expect(hasMagicLayerChanges(image([layer({ hidden: true })]))).toBe(true);
+  });
+
+  it('returns true when any layer in a mix is moved', () => {
+    expect(hasMagicLayerChanges(image([layer(), layer({ position: { x: 15, y: 20 } })]))).toBe(true);
+  });
+
+  it('returns true when any layer in a mix is hidden', () => {
+    expect(hasMagicLayerChanges(image([layer(), layer({ hidden: true })]))).toBe(true);
+  });
+
+  it('returns true only when position differs from sourceBounds in x or y', () => {
+    expect(isLayerMoved(layer())).toBe(false);
+    expect(isLayerMoved(layer({ position: { x: 11, y: 20 } }))).toBe(true);
+    expect(isLayerMoved(layer({ position: { x: 10, y: 21 } }))).toBe(true);
+  });
+});

--- a/src/lib/canvas/magic-layer-changes.ts
+++ b/src/lib/canvas/magic-layer-changes.ts
@@ -1,0 +1,9 @@
+import type { CanvasImage, MagicLayer } from '@/types/canvas';
+
+export function isLayerMoved(layer: MagicLayer): boolean {
+  return layer.position.x !== layer.sourceBounds.x || layer.position.y !== layer.sourceBounds.y;
+}
+
+export function hasMagicLayerChanges(image: Pick<CanvasImage, 'magicLayers'>): boolean {
+  return image.magicLayers?.some((layer) => layer.hidden === true || isLayerMoved(layer)) ?? false;
+}

--- a/src/lib/canvas/magic-layer.ts
+++ b/src/lib/canvas/magic-layer.ts
@@ -43,8 +43,48 @@ function rectMask(bounds: { width: number; height: number }): string {
   return canvas.toDataURL('image/png');
 }
 
-async function cropCutout(base: HTMLImageElement, maskDataUrl: string, bounds: { x: number; y: number; width: number; height: number }, imageSize: { width: number; height: number }): Promise<string> {
-  const mask = await loadImage(maskDataUrl);
+function normalizeMaskToAlpha(mask: HTMLImageElement): HTMLCanvasElement {
+  const canvas = document.createElement('canvas');
+  canvas.width = mask.naturalWidth;
+  canvas.height = mask.naturalHeight;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return canvas;
+
+  ctx.drawImage(mask, 0, 0);
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  const { data } = imageData;
+  for (let index = 0; index < data.length; index += 4) {
+    const luminance = Math.max(data[index], data[index + 1], data[index + 2]);
+    const originalAlpha = data[index + 3];
+    const alpha = originalAlpha < 255 ? originalAlpha : luminance;
+    data[index] = 255;
+    data[index + 1] = 255;
+    data[index + 2] = 255;
+    data[index + 3] = alpha;
+  }
+  ctx.putImageData(imageData, 0, 0);
+  return canvas;
+}
+
+function drawMaskCrop(
+  ctx: CanvasRenderingContext2D,
+  mask: HTMLCanvasElement,
+  bounds: { x: number; y: number; width: number; height: number },
+  imageSize: { width: number; height: number },
+) {
+  if (mask.width === imageSize.width && mask.height === imageSize.height) {
+    ctx.drawImage(mask, bounds.x, bounds.y, bounds.width, bounds.height, 0, 0, bounds.width, bounds.height);
+  } else {
+    ctx.drawImage(mask, 0, 0, bounds.width, bounds.height);
+  }
+}
+
+async function cropCutout(
+  base: HTMLImageElement,
+  mask: HTMLCanvasElement,
+  bounds: { x: number; y: number; width: number; height: number },
+  imageSize: { width: number; height: number },
+): Promise<string> {
   const canvas = document.createElement('canvas');
   canvas.width = bounds.width;
   canvas.height = bounds.height;
@@ -53,21 +93,33 @@ async function cropCutout(base: HTMLImageElement, maskDataUrl: string, bounds: {
 
   ctx.drawImage(base, bounds.x, bounds.y, bounds.width, bounds.height, 0, 0, bounds.width, bounds.height);
   ctx.globalCompositeOperation = 'destination-in';
-  if (mask.naturalWidth === imageSize.width && mask.naturalHeight === imageSize.height) {
-    ctx.drawImage(mask, bounds.x, bounds.y, bounds.width, bounds.height, 0, 0, bounds.width, bounds.height);
-  } else {
-    ctx.drawImage(mask, 0, 0, bounds.width, bounds.height);
-  }
+  drawMaskCrop(ctx, mask, bounds, imageSize);
   ctx.globalCompositeOperation = 'source-over';
   return canvas.toDataURL('image/png');
 }
 
-function fillRemovedRegion(ctx: CanvasRenderingContext2D, bounds: { x: number; y: number; width: number; height: number }, imageSize: { width: number; height: number }) {
+function fillRemovedRegion(
+  ctx: CanvasRenderingContext2D,
+  mask: HTMLCanvasElement,
+  bounds: { x: number; y: number; width: number; height: number },
+  imageSize: { width: number; height: number },
+) {
   const sampleX = Math.max(0, Math.min(imageSize.width - 1, bounds.x - 1));
   const sampleY = Math.max(0, Math.min(imageSize.height - 1, bounds.y + Math.floor(bounds.height / 2)));
   const pixel = ctx.getImageData(sampleX, sampleY, 1, 1).data;
-  ctx.fillStyle = `rgb(${pixel[0]} ${pixel[1]} ${pixel[2]})`;
-  ctx.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
+
+  const patch = document.createElement('canvas');
+  patch.width = bounds.width;
+  patch.height = bounds.height;
+  const patchCtx = patch.getContext('2d');
+  if (!patchCtx) return;
+  patchCtx.fillStyle = `rgb(${pixel[0]} ${pixel[1]} ${pixel[2]})`;
+  patchCtx.fillRect(0, 0, bounds.width, bounds.height);
+  patchCtx.globalCompositeOperation = 'destination-in';
+  drawMaskCrop(patchCtx, mask, bounds, imageSize);
+  patchCtx.globalCompositeOperation = 'source-over';
+
+  ctx.drawImage(patch, bounds.x, bounds.y);
 }
 
 export async function buildMagicLayerComposite({ imageUrl, imageSize, segments }: BuildMagicLayersOptions): Promise<{ baseUrl: string; layers: MagicLayer[] }> {
@@ -83,9 +135,10 @@ export async function buildMagicLayerComposite({ imageUrl, imageSize, segments }
   for (const [index, segment] of segments.entries()) {
     const bounds = clampBounds(segment.bbox, imageSize);
     const maskDataUrl = segment.maskDataUrl || rectMask(bounds);
-    const cutoutDataUrl = await cropCutout(base, maskDataUrl, bounds, imageSize);
+    const mask = normalizeMaskToAlpha(await loadImage(maskDataUrl));
+    const cutoutDataUrl = await cropCutout(base, mask, bounds, imageSize);
     if (!cutoutDataUrl) continue;
-    fillRemovedRegion(baseCtx, bounds, imageSize);
+    fillRemovedRegion(baseCtx, mask, bounds, imageSize);
     layers.push({
       id: segment.id || `magic-layer-${index + 1}`,
       name: segment.label || `Layer ${index + 1}`,

--- a/src/lib/canvas/magic-layer.ts
+++ b/src/lib/canvas/magic-layer.ts
@@ -1,0 +1,101 @@
+import type { MagicLayer } from '@/types/canvas';
+
+export interface MagicLayerSegment {
+  id?: string;
+  label?: string;
+  maskDataUrl?: string;
+  bbox: { x: number; y: number; width: number; height: number };
+}
+
+export interface BuildMagicLayersOptions {
+  imageUrl: string;
+  imageSize: { width: number; height: number };
+  segments: MagicLayerSegment[];
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Failed to load image for Magic Layer'));
+    img.src = src;
+  });
+}
+
+function clampBounds(bounds: MagicLayerSegment['bbox'], size: { width: number; height: number }) {
+  const x = Math.max(0, Math.min(size.width, Math.round(bounds.x)));
+  const y = Math.max(0, Math.min(size.height, Math.round(bounds.y)));
+  const right = Math.max(x + 1, Math.min(size.width, Math.round(bounds.x + bounds.width)));
+  const bottom = Math.max(y + 1, Math.min(size.height, Math.round(bounds.y + bounds.height)));
+  return { x, y, width: right - x, height: bottom - y };
+}
+
+function rectMask(bounds: { width: number; height: number }): string {
+  const canvas = document.createElement('canvas');
+  canvas.width = bounds.width;
+  canvas.height = bounds.height;
+  const ctx = canvas.getContext('2d');
+  if (ctx) {
+    ctx.fillStyle = '#fff';
+    ctx.fillRect(0, 0, bounds.width, bounds.height);
+  }
+  return canvas.toDataURL('image/png');
+}
+
+async function cropCutout(base: HTMLImageElement, maskDataUrl: string, bounds: { x: number; y: number; width: number; height: number }, imageSize: { width: number; height: number }): Promise<string> {
+  const mask = await loadImage(maskDataUrl);
+  const canvas = document.createElement('canvas');
+  canvas.width = bounds.width;
+  canvas.height = bounds.height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return '';
+
+  ctx.drawImage(base, bounds.x, bounds.y, bounds.width, bounds.height, 0, 0, bounds.width, bounds.height);
+  ctx.globalCompositeOperation = 'destination-in';
+  if (mask.naturalWidth === imageSize.width && mask.naturalHeight === imageSize.height) {
+    ctx.drawImage(mask, bounds.x, bounds.y, bounds.width, bounds.height, 0, 0, bounds.width, bounds.height);
+  } else {
+    ctx.drawImage(mask, 0, 0, bounds.width, bounds.height);
+  }
+  ctx.globalCompositeOperation = 'source-over';
+  return canvas.toDataURL('image/png');
+}
+
+function fillRemovedRegion(ctx: CanvasRenderingContext2D, bounds: { x: number; y: number; width: number; height: number }, imageSize: { width: number; height: number }) {
+  const sampleX = Math.max(0, Math.min(imageSize.width - 1, bounds.x - 1));
+  const sampleY = Math.max(0, Math.min(imageSize.height - 1, bounds.y + Math.floor(bounds.height / 2)));
+  const pixel = ctx.getImageData(sampleX, sampleY, 1, 1).data;
+  ctx.fillStyle = `rgb(${pixel[0]} ${pixel[1]} ${pixel[2]})`;
+  ctx.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
+}
+
+export async function buildMagicLayerComposite({ imageUrl, imageSize, segments }: BuildMagicLayersOptions): Promise<{ baseUrl: string; layers: MagicLayer[] }> {
+  const base = await loadImage(imageUrl);
+  const baseCanvas = document.createElement('canvas');
+  baseCanvas.width = imageSize.width;
+  baseCanvas.height = imageSize.height;
+  const baseCtx = baseCanvas.getContext('2d');
+  if (!baseCtx) throw new Error('Canvas is unavailable for Magic Layer');
+  baseCtx.drawImage(base, 0, 0, imageSize.width, imageSize.height);
+
+  const layers: MagicLayer[] = [];
+  for (const [index, segment] of segments.entries()) {
+    const bounds = clampBounds(segment.bbox, imageSize);
+    const maskDataUrl = segment.maskDataUrl || rectMask(bounds);
+    const cutoutDataUrl = await cropCutout(base, maskDataUrl, bounds, imageSize);
+    if (!cutoutDataUrl) continue;
+    fillRemovedRegion(baseCtx, bounds, imageSize);
+    layers.push({
+      id: segment.id || `magic-layer-${index + 1}`,
+      name: segment.label || `Layer ${index + 1}`,
+      maskDataUrl,
+      cutoutDataUrl,
+      sourceBounds: bounds,
+      position: { x: bounds.x, y: bounds.y },
+      hidden: false,
+    });
+  }
+
+  return { baseUrl: baseCanvas.toDataURL('image/png'), layers };
+}

--- a/src/lib/magic-layer/runner.ts
+++ b/src/lib/magic-layer/runner.ts
@@ -1,0 +1,385 @@
+import path from 'node:path';
+import os from 'node:os';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdir, readFile, writeFile, rename, access, stat, rm } from 'node:fs/promises';
+import { getRuntimeDir } from '@/lib/projects/paths';
+
+const execFileAsync = promisify(execFile);
+
+const MLX_SAM3_REPO_URL = 'https://github.com/Deekshith-Dade/mlx_sam3.git';
+const MLX_SAM3_REPO_REF = 'main';
+const MLX_SAM3_PYTHON_VERSION = '3.13';
+const MLX_SAM3_LEAN_DEPS = [
+  'mlx>=0.30.0',
+  'numpy>=2.3.5',
+  'pillow>=12.0.0',
+  'torch>=2.9.1',
+  'torchvision>=0.24.1',
+  'huggingface-hub>=1.1.6',
+  'ftfy>=6.3.1',
+  'regex>=2025.11.3',
+  'iopath>=0.1.10',
+];
+const INSTALL_MANIFEST_VERSION = 1;
+const STALE_LOCK_MS = 60 * 60 * 1000;
+
+export type Sam3Source = 'env' | 'auto-mlx' | 'fallback';
+
+export interface ResolvedSam3Command {
+  source: Sam3Source;
+  argv: string[] | null;
+  reason?: string;
+}
+
+export interface InstallManifest {
+  installVersion: number;
+  installedAt: string;
+  pythonVersion: string;
+  repoUrl: string;
+  repoRef: string;
+  deps: string[];
+  pythonPath: string;
+  scriptPath: string;
+}
+
+export interface InstallStatus {
+  installed: boolean;
+  installing: boolean;
+  failed: boolean;
+  message: string;
+  errorCode?: string;
+  startedAt?: string;
+  updatedAt?: string;
+  canFallback: boolean;
+}
+
+export function isAutoInstallSupported(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (env.BANANATAPE_DISABLE_AUTO_INSTALL === '1') return false;
+  if (env.CI === 'true') return false;
+  return process.platform === 'darwin' && process.arch === 'arm64';
+}
+
+export function getMlxInstallDir(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(getRuntimeDir(env), 'mlx_sam3');
+}
+
+function getVenvPythonPath(installDir: string): string {
+  return path.join(installDir, '.venv', 'bin', 'python');
+}
+
+function getManifestPath(installDir: string): string {
+  return path.join(installDir, 'install.json');
+}
+
+function getLockPath(installDir: string): string {
+  return path.join(installDir, 'install.lock');
+}
+
+function getStatusPath(installDir: string): string {
+  return path.join(installDir, 'status.json');
+}
+
+function getInstallLogPath(installDir: string): string {
+  return path.join(installDir, 'install.log');
+}
+
+export function getBundledMlxScriptPath(): string {
+  return path.resolve(process.cwd(), 'scripts', 'sam3-magic-layer-mlx.py');
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readManifest(installDir: string): Promise<InstallManifest | null> {
+  try {
+    const raw = await readFile(getManifestPath(installDir), 'utf8');
+    const parsed = JSON.parse(raw) as InstallManifest;
+    if (parsed.installVersion !== INSTALL_MANIFEST_VERSION) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+async function writeStatus(installDir: string, status: InstallStatus): Promise<void> {
+  await mkdir(installDir, { recursive: true });
+  const tmp = `${getStatusPath(installDir)}.tmp`;
+  await writeFile(tmp, JSON.stringify(status, null, 2), 'utf8');
+  await rename(tmp, getStatusPath(installDir));
+}
+
+async function readStatus(installDir: string): Promise<InstallStatus | null> {
+  try {
+    const raw = await readFile(getStatusPath(installDir), 'utf8');
+    return JSON.parse(raw) as InstallStatus;
+  } catch {
+    return null;
+  }
+}
+
+async function isLockStale(lockPath: string): Promise<boolean> {
+  try {
+    const s = await stat(lockPath);
+    return Date.now() - s.mtimeMs > STALE_LOCK_MS;
+  } catch {
+    return false;
+  }
+}
+
+async function acquireLock(installDir: string): Promise<boolean> {
+  await mkdir(installDir, { recursive: true });
+  const lockPath = getLockPath(installDir);
+  try {
+    await writeFile(lockPath, JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() }), { flag: 'wx' });
+    return true;
+  } catch {
+    if (await isLockStale(lockPath)) {
+      await writeFile(lockPath, JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() }), { flag: 'w' });
+      return true;
+    }
+    return false;
+  }
+}
+
+async function releaseLock(installDir: string): Promise<void> {
+  try {
+    const { unlink } = await import('node:fs/promises');
+    await unlink(getLockPath(installDir));
+  } catch {
+    return;
+  }
+}
+
+async function appendLog(installDir: string, line: string): Promise<void> {
+  try {
+    const { appendFile } = await import('node:fs/promises');
+    await appendFile(getInstallLogPath(installDir), `[${new Date().toISOString()}] ${line}\n`, 'utf8');
+  } catch {
+    return;
+  }
+}
+
+async function verifyInstalledManifest(manifest: InstallManifest): Promise<boolean> {
+  if (!(await pathExists(manifest.pythonPath))) return false;
+  if (!(await pathExists(manifest.scriptPath))) return false;
+  try {
+    await execFileAsync(manifest.pythonPath, ['-c', 'from sam3 import build_sam3_image_model; from sam3.model.sam3_image_processor import Sam3Processor'], { timeout: 30_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function commandExists(bin: string): Promise<boolean> {
+  try {
+    await execFileAsync('which', [bin], { timeout: 5_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findUv(env: NodeJS.ProcessEnv): Promise<string | null> {
+  if (env.BANANATAPE_UV_PATH && (await pathExists(env.BANANATAPE_UV_PATH))) return env.BANANATAPE_UV_PATH;
+  for (const candidate of ['uv', path.join(os.homedir(), '.local', 'bin', 'uv'), '/opt/homebrew/bin/uv', '/usr/local/bin/uv']) {
+    if (path.isAbsolute(candidate)) {
+      if (await pathExists(candidate)) return candidate;
+    } else if (await commandExists(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+export interface InstallAttemptResult {
+  status: 'started' | 'already-installing' | 'already-installed' | 'unsupported' | 'missing-uv' | 'failed';
+  message: string;
+  errorCode?: string;
+}
+
+async function performInstall(installDir: string, uvPath: string, scriptPath: string): Promise<void> {
+  const venvPython = getVenvPythonPath(installDir);
+  const srcDir = path.join(installDir, 'mlx_sam3-src');
+
+  await writeStatus(installDir, {
+    installed: false,
+    installing: true,
+    failed: false,
+    message: 'Creating Python 3.13 environment with uv...',
+    startedAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    canFallback: true,
+  });
+  await appendLog(installDir, 'starting install');
+
+  await execFileAsync(uvPath, ['venv', '--python', MLX_SAM3_PYTHON_VERSION, path.join(installDir, '.venv')], { timeout: 5 * 60 * 1000 });
+
+  await writeStatus(installDir, {
+    installed: false,
+    installing: true,
+    failed: false,
+    message: 'Installing lean Python dependencies (torch, mlx, ...)',
+    updatedAt: new Date().toISOString(),
+    canFallback: true,
+  });
+
+  await execFileAsync(uvPath, ['pip', 'install', '--python', venvPython, ...MLX_SAM3_LEAN_DEPS], { timeout: 15 * 60 * 1000, maxBuffer: 50 * 1024 * 1024 });
+
+  await writeStatus(installDir, {
+    installed: false,
+    installing: true,
+    failed: false,
+    message: 'Cloning mlx_sam3 source (preserves bundled BPE tokenizer assets)...',
+    updatedAt: new Date().toISOString(),
+    canFallback: true,
+  });
+
+  await rm(srcDir, { recursive: true, force: true });
+  await execFileAsync('git', ['clone', '--depth', '1', '--branch', MLX_SAM3_REPO_REF, MLX_SAM3_REPO_URL, srcDir], { timeout: 5 * 60 * 1000 });
+
+  await execFileAsync(uvPath, ['pip', 'install', '--python', venvPython, '--no-deps', '-e', srcDir], { timeout: 5 * 60 * 1000, maxBuffer: 50 * 1024 * 1024 });
+
+  await execFileAsync(venvPython, ['-c', 'from sam3 import build_sam3_image_model; from sam3.model.sam3_image_processor import Sam3Processor'], { timeout: 60_000 });
+
+  const manifest: InstallManifest = {
+    installVersion: INSTALL_MANIFEST_VERSION,
+    installedAt: new Date().toISOString(),
+    pythonVersion: MLX_SAM3_PYTHON_VERSION,
+    repoUrl: MLX_SAM3_REPO_URL,
+    repoRef: MLX_SAM3_REPO_REF,
+    deps: MLX_SAM3_LEAN_DEPS,
+    pythonPath: venvPython,
+    scriptPath,
+  };
+  const tmp = `${getManifestPath(installDir)}.tmp`;
+  await writeFile(tmp, JSON.stringify(manifest, null, 2), 'utf8');
+  await rename(tmp, getManifestPath(installDir));
+
+  await writeStatus(installDir, {
+    installed: true,
+    installing: false,
+    failed: false,
+    message: 'mlx_sam3 ready. First Magic Layer run downloads ~3.4GB of model weights.',
+    updatedAt: new Date().toISOString(),
+    canFallback: true,
+  });
+  await appendLog(installDir, 'install complete');
+}
+
+let inFlight: Promise<void> | null = null;
+
+export async function startInstallInBackground(env: NodeJS.ProcessEnv = process.env): Promise<InstallAttemptResult> {
+  if (!isAutoInstallSupported(env)) {
+    return { status: 'unsupported', message: 'Auto-install only runs on macOS Apple Silicon.' };
+  }
+
+  const installDir = getMlxInstallDir(env);
+  const scriptPath = getBundledMlxScriptPath();
+
+  if (!(await pathExists(scriptPath))) {
+    return { status: 'failed', message: `Bundled mlx wrapper script not found: ${scriptPath}`, errorCode: 'SCRIPT_MISSING' };
+  }
+
+  const manifest = await readManifest(installDir);
+  if (manifest && (await verifyInstalledManifest(manifest))) {
+    return { status: 'already-installed', message: 'mlx_sam3 already installed.' };
+  }
+
+  if (inFlight) return { status: 'already-installing', message: 'Install already in progress.' };
+
+  const uvPath = await findUv(env);
+  if (!uvPath) {
+    return {
+      status: 'missing-uv',
+      message: 'uv (Astral) is required for auto-install. Install once: curl -LsSf https://astral.sh/uv/install.sh | sh',
+      errorCode: 'UV_NOT_FOUND',
+    };
+  }
+
+  const acquired = await acquireLock(installDir);
+  if (!acquired) return { status: 'already-installing', message: 'Another process is installing mlx_sam3.' };
+
+  inFlight = (async () => {
+    try {
+      await performInstall(installDir, uvPath, scriptPath);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Install failed';
+      await writeStatus(installDir, {
+        installed: false,
+        installing: false,
+        failed: true,
+        message: `Install failed: ${message}`,
+        errorCode: 'INSTALL_FAILED',
+        updatedAt: new Date().toISOString(),
+        canFallback: true,
+      });
+      await appendLog(installDir, `FAILED: ${message}`);
+    } finally {
+      await releaseLock(installDir);
+      inFlight = null;
+    }
+  })();
+
+  void inFlight;
+
+  return { status: 'started', message: 'mlx_sam3 install started in background.' };
+}
+
+export async function readInstallStatus(env: NodeJS.ProcessEnv = process.env): Promise<InstallStatus> {
+  const installDir = getMlxInstallDir(env);
+  const manifest = await readManifest(installDir);
+  if (manifest && (await verifyInstalledManifest(manifest))) {
+    return {
+      installed: true,
+      installing: false,
+      failed: false,
+      message: 'mlx_sam3 ready.',
+      updatedAt: manifest.installedAt,
+      canFallback: true,
+    };
+  }
+  const persisted = await readStatus(installDir);
+  if (persisted) return persisted;
+  return {
+    installed: false,
+    installing: inFlight !== null,
+    failed: false,
+    message: 'Not installed yet.',
+    canFallback: true,
+  };
+}
+
+export async function resolveSam3Command(env: NodeJS.ProcessEnv = process.env): Promise<ResolvedSam3Command> {
+  const explicit = env.BANANATAPE_SAM3_COMMAND?.trim();
+  if (explicit) {
+    return { source: 'env', argv: explicit.split(/\s+/) };
+  }
+
+  if (!isAutoInstallSupported(env)) {
+    return {
+      source: 'fallback',
+      argv: null,
+      reason: env.BANANATAPE_DISABLE_AUTO_INSTALL === '1'
+        ? 'auto-install disabled via env'
+        : `unsupported platform ${process.platform}/${process.arch}`,
+    };
+  }
+
+  const installDir = getMlxInstallDir(env);
+  const manifest = await readManifest(installDir);
+  if (manifest && (await verifyInstalledManifest(manifest))) {
+    return {
+      source: 'auto-mlx',
+      argv: [manifest.pythonPath, manifest.scriptPath],
+    };
+  }
+
+  return { source: 'fallback', argv: null, reason: 'auto-mlx not yet installed' };
+}

--- a/src/lib/prompt/magic-layer-inpaint.test.ts
+++ b/src/lib/prompt/magic-layer-inpaint.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { MAGIC_LAYER_INPAINT_INSTRUCTION, composeMagicLayerPrompt } from './magic-layer-inpaint';
+
+describe('composeMagicLayerPrompt', () => {
+  it('returns only the instruction when input is undefined', () => {
+    expect(composeMagicLayerPrompt(undefined)).toBe(MAGIC_LAYER_INPAINT_INSTRUCTION);
+  });
+
+  it('returns only the instruction when input is an empty string', () => {
+    expect(composeMagicLayerPrompt('')).toBe(MAGIC_LAYER_INPAINT_INSTRUCTION);
+  });
+
+  it('returns only the instruction when input is whitespace-only', () => {
+    expect(composeMagicLayerPrompt('   \n\t  ')).toBe(MAGIC_LAYER_INPAINT_INSTRUCTION);
+  });
+
+  it('appends the instruction to a normal prompt', () => {
+    expect(composeMagicLayerPrompt('Make the scene feel brighter')).toBe(
+      `Make the scene feel brighter\n\n${MAGIC_LAYER_INPAINT_INSTRUCTION}`,
+    );
+  });
+
+  it('trims surrounding whitespace from the original prompt', () => {
+    expect(composeMagicLayerPrompt('  Keep the red chair in place  \n')).toBe(
+      `Keep the red chair in place\n\n${MAGIC_LAYER_INPAINT_INSTRUCTION}`,
+    );
+  });
+});

--- a/src/lib/prompt/magic-layer-inpaint.ts
+++ b/src/lib/prompt/magic-layer-inpaint.ts
@@ -1,0 +1,12 @@
+export const MAGIC_LAYER_INPAINT_INSTRUCTION =
+  "The composition has been rearranged: some objects were moved and some were removed. Inpaint the empty regions where objects used to be so they blend naturally with the surrounding scene. Integrate the moved objects into their new positions with matching lighting, shadows, perspective, and edges. Preserve the moved objects' identity, scale, and new positions. Output a single coherent, photorealistic image.";
+
+export function composeMagicLayerPrompt(originalPrompt: string | undefined): string {
+  const trimmedOriginal = originalPrompt?.trim();
+
+  if (!trimmedOriginal) {
+    return MAGIC_LAYER_INPAINT_INSTRUCTION;
+  }
+
+  return `${trimmedOriginal}\n\n${MAGIC_LAYER_INPAINT_INSTRUCTION}`;
+}

--- a/src/stores/useCanvasStore.test.ts
+++ b/src/stores/useCanvasStore.test.ts
@@ -225,6 +225,41 @@ describe('useCanvasStore', () => {
     expect(useCanvasStore.getState().images.a.memos).toEqual([{ ...memo, text: '' }]);
   });
 
+
+  it('stores, moves, hides, and clears Magic Layers with image undo support', () => {
+    useCanvasStore.getState().addImage(makeImage('a'));
+    const layer = {
+      id: 'layer-1',
+      name: 'Text',
+      maskDataUrl: 'data:image/png;base64,mask',
+      cutoutDataUrl: 'data:image/png;base64,cutout',
+      sourceBounds: { x: 10, y: 20, width: 100, height: 40 },
+      position: { x: 10, y: 20 },
+      hidden: false,
+    };
+
+    useCanvasStore.getState().setMagicLayers('a', [layer], 'data:image/png;base64,base');
+    expect(useCanvasStore.getState().images.a).toMatchObject({
+      magicLayerStatus: 'ready',
+      magicLayerBaseUrl: 'data:image/png;base64,base',
+      selectedMagicLayerId: 'layer-1',
+    });
+
+    useCanvasStore.getState().updateMagicLayer('a', 'layer-1', { position: { x: 80, y: 90 } });
+    expect(useCanvasStore.getState().images.a.magicLayers?.[0].position).toEqual({ x: 80, y: 90 });
+
+    useCanvasStore.getState().hideMagicLayer('a', 'layer-1');
+    expect(useCanvasStore.getState().images.a.magicLayers?.[0].hidden).toBe(true);
+    expect(useCanvasStore.getState().images.a.selectedMagicLayerId).toBeNull();
+
+    useCanvasStore.getState().undoImage('a');
+    expect(useCanvasStore.getState().images.a.magicLayers?.[0].hidden).toBe(false);
+
+    useCanvasStore.getState().clearMagicLayers('a');
+    expect(useCanvasStore.getState().images.a.magicLayers).toEqual([]);
+    expect(useCanvasStore.getState().images.a.magicLayerBaseUrl).toBeUndefined();
+  });
+
   it('setImageStatus does not push an undo entry', () => {
     useCanvasStore.getState().addImage(makeImage('a', 'pending'));
     const before = pastLength();

--- a/src/stores/useCanvasStore.ts
+++ b/src/stores/useCanvasStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { temporal } from 'zundo';
 import { devtools } from 'zustand/middleware';
-import type { CanvasImage, GenerationStatus } from '@/types/canvas';
+import type { CanvasImage, GenerationStatus, MagicLayer, MagicLayerStatus } from '@/types/canvas';
 import type { DrawingPath, BoundingBox, TextMemo } from '@/types';
 
 const MIN_ZOOM = 0.1;
@@ -46,6 +46,13 @@ export interface CanvasActions {
   removeMemoFromImage(imageId: string, memoId: string, options?: { track?: boolean; historySnapshot?: CanvasImage }): void;
 
   clearAnnotationsOnImage(imageId: string): void;
+
+  setMagicLayerStatus(imageId: string, status: MagicLayerStatus, error?: string): void;
+  setMagicLayers(imageId: string, layers: MagicLayer[], baseUrl: string): void;
+  selectMagicLayer(imageId: string, layerId: string | null): void;
+  updateMagicLayer(imageId: string, layerId: string, patch: Partial<Omit<MagicLayer, 'id'>>, options?: { track?: boolean }): void;
+  hideMagicLayer(imageId: string, layerId: string): void;
+  clearMagicLayers(imageId: string): void;
 
   undoImage(imageId: string): void;
   redoImage(imageId: string): void;
@@ -242,6 +249,31 @@ export const useCanvasStore = create<CanvasStore>()(
         memos: image.memos.filter((memo) => memo.id !== memoId),
       }), options),
       clearAnnotationsOnImage: (imageId) => mutateImage(set, imageId, (image) => ({ ...image, paths: [], boxes: [], memos: [] })),
+      setMagicLayerStatus: (imageId, status, error) => mutateImage(set, imageId, (image) => ({ ...image, magicLayerStatus: status, error }), { track: false }),
+      setMagicLayers: (imageId, layers, baseUrl) => mutateImage(set, imageId, (image) => ({
+        ...image,
+        magicLayers: layers,
+        magicLayerBaseUrl: baseUrl,
+        magicLayerStatus: 'ready',
+        selectedMagicLayerId: layers[0]?.id ?? null,
+      })),
+      selectMagicLayer: (imageId, layerId) => mutateImage(set, imageId, (image) => ({ ...image, selectedMagicLayerId: layerId }), { track: false }),
+      updateMagicLayer: (imageId, layerId, patch, options) => mutateImage(set, imageId, (image) => ({
+        ...image,
+        magicLayers: (image.magicLayers ?? []).map((layer) => (layer.id === layerId ? { ...layer, ...patch } : layer)),
+      }), options),
+      hideMagicLayer: (imageId, layerId) => mutateImage(set, imageId, (image) => ({
+        ...image,
+        magicLayers: (image.magicLayers ?? []).map((layer) => (layer.id === layerId ? { ...layer, hidden: true } : layer)),
+        selectedMagicLayerId: image.selectedMagicLayerId === layerId ? null : image.selectedMagicLayerId,
+      })),
+      clearMagicLayers: (imageId) => mutateImage(set, imageId, (image) => ({
+        ...image,
+        magicLayers: [],
+        magicLayerBaseUrl: undefined,
+        magicLayerStatus: 'idle',
+        selectedMagicLayerId: null,
+      })),
       undoImage: (imageId) => withTemporalPaused(() => set((state) => {
         const image = state.images[imageId];
         const history = state.imageHistories[imageId];

--- a/src/types/canvas.ts
+++ b/src/types/canvas.ts
@@ -3,6 +3,18 @@ import type { DrawingPath, BoundingBox, TextMemo } from './index';
 
 export type GenerationStatus = 'pending' | 'streaming' | 'ready' | 'error';
 
+export interface MagicLayer {
+  id: string;
+  name: string;
+  maskDataUrl: string;
+  cutoutDataUrl: string;
+  sourceBounds: { x: number; y: number; width: number; height: number };
+  position: { x: number; y: number };
+  hidden: boolean;
+}
+
+export type MagicLayerStatus = 'idle' | 'segmenting' | 'ready' | 'error';
+
 export interface CanvasImage {
   id: string;
   url: string;
@@ -18,6 +30,10 @@ export interface CanvasImage {
   paths: DrawingPath[];
   boxes: BoundingBox[];
   memos: TextMemo[];
+  magicLayers?: MagicLayer[];
+  magicLayerBaseUrl?: string;
+  magicLayerStatus?: MagicLayerStatus;
+  selectedMagicLayerId?: string | null;
   status: GenerationStatus;
   error?: string;
 }

--- a/src/types/canvas.ts
+++ b/src/types/canvas.ts
@@ -13,7 +13,7 @@ export interface MagicLayer {
   hidden: boolean;
 }
 
-export type MagicLayerStatus = 'idle' | 'segmenting' | 'ready' | 'error';
+export type MagicLayerStatus = 'idle' | 'preparing' | 'segmenting' | 'ready' | 'error';
 
 export interface CanvasImage {
   id: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export type Tool = 'pan' | 'move' | 'pen' | 'box' | 'arrow' | 'memo';
+export type Tool = 'pan' | 'move' | 'pen' | 'box' | 'arrow' | 'memo' | 'magic-layer';
 export type Provider = 'openai' | 'god-tibo';
 export type Mode = 'generate' | 'edit';
 export type AnnotationStatus = 'pending' | 'review' | 'accepted';

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -1089,6 +1089,100 @@ test.describe('BananaTape Editor', () => {
     await expect(layer).toHaveCount(0);
   });
 
+  test('Magic Layer Apply triggers an edit generation with the moved composition', async ({ page }) => {
+    let editRequestCount = 0;
+    let capturedEditPrompt: string | null = null;
+    let capturedEditFormDataKeys: string[] = [];
+
+    await page.unroute('/api/edit');
+    await page.route('/api/edit', async (route) => {
+      editRequestCount += 1;
+      const post = route.request().postData() ?? '';
+      const promptMatch = post.match(/name="prompt"\r?\n\r?\n([\s\S]*?)(?=\r?\n--)/);
+      if (promptMatch) capturedEditPrompt = promptMatch[1];
+      const fieldRe = /name="([^"]+)"/g;
+      const names: string[] = [];
+      let m: RegExpExecArray | null;
+      while ((m = fieldRe.exec(post)) !== null) names.push(m[1]);
+      capturedEditFormDataKeys = names;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          imageDataUrl: FAKE_IMAGE_DATA_URL,
+          prompt: 'edited via magic layer',
+          provider: 'openai',
+        }),
+      });
+    });
+
+    const promptInput = getPromptInput(page);
+    await promptInput.fill('magic layer apply test');
+    await getGenerateButton(page).click();
+    await expect(page.getByAltText('Canvas base')).toHaveAttribute('src', FAKE_IMAGE_DATA_URL);
+
+    const magicResponse = page.waitForResponse((response) => response.url().includes('/api/magic-layer') && response.request().method() === 'POST');
+    await page.locator('button[title="Segment selected image into draggable Magic Layers"]').click();
+    const response = await magicResponse;
+    expect(response.ok()).toBeTruthy();
+
+    const overlay = page.locator('[data-testid="magic-layer-overlay"]');
+    await expect(overlay).toBeVisible();
+
+    const magicTool = page.locator('button[title="Magic Layer (7)"]');
+    await magicTool.click();
+
+    await expect(page.locator('[data-testid="magic-layer-apply"]')).toHaveCount(0);
+
+    const firstLayerId = await page.locator('[data-testid="magic-layer-item"]').first().getAttribute('data-magic-layer-id');
+    if (!firstLayerId) throw new Error('Magic layer id missing');
+    const layer = page.locator(`[data-testid="magic-layer-item"][data-magic-layer-id="${firstLayerId}"]`);
+    const before = await layer.boundingBox();
+    if (!before) throw new Error('Magic layer was not visible');
+    await page.mouse.move(before.x + before.width / 2, before.y + before.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(before.x + before.width / 2 + 60, before.y + before.height / 2 + 30, { steps: 6 });
+    await page.mouse.up();
+
+    await expect.poll(async () => {
+      const after = await layer.boundingBox();
+      return after ? Math.round(after.x - before.x) : 0;
+    }).toBeGreaterThan(20);
+
+    const applyBtn = page.locator('[data-testid="magic-layer-apply"]');
+    await expect(applyBtn).toBeVisible();
+    await expect(applyBtn).toBeEnabled();
+
+    const applyBoxRect = await applyBtn.boundingBox();
+    const baseBoxRect = await page.getByAltText('Canvas base').first().boundingBox();
+    if (!applyBoxRect || !baseBoxRect) throw new Error('Apply or base image bbox missing');
+    expect(applyBoxRect.y + applyBoxRect.height).toBeLessThanOrEqual(baseBoxRect.y + baseBoxRect.height / 2);
+    expect(baseBoxRect.x + baseBoxRect.width - (applyBoxRect.x + applyBoxRect.width)).toBeLessThan(100);
+
+    const deleteBtnBox = await page.locator('button[aria-label="Delete image"]').first().boundingBox();
+    if (deleteBtnBox) {
+      expect(deleteBtnBox.x).toBeGreaterThanOrEqual(applyBoxRect.x + applyBoxRect.width - 1);
+    }
+
+    const editRequest = page.waitForRequest((req) => req.url().includes('/api/edit') && req.method() === 'POST');
+    await applyBtn.click();
+    await editRequest;
+
+    await expect.poll(() => editRequestCount).toBe(1);
+    expect(capturedEditPrompt).toBeTruthy();
+    expect(capturedEditPrompt).toContain('Inpaint the empty regions where objects used to be');
+    expect(capturedEditPrompt).toContain('magic layer apply test');
+    expect(capturedEditFormDataKeys).toContain('prompt');
+    expect(capturedEditFormDataKeys).toContain('parentId');
+    expect(capturedEditFormDataKeys).toContain('images');
+    expect(capturedEditFormDataKeys).toContain('maskImage');
+    expect(capturedEditFormDataKeys).toContain('size');
+
+    await expect(page.getByAltText('Canvas base')).toHaveCount(2, { timeout: 5000 });
+    await expect(page.getByText(/Magic Layer applied/i)).toBeVisible();
+  });
+
   test('draws pen stroke after zooming', async ({ page }) => {
     const promptInput = getPromptInput(page);
     await promptInput.fill('zoomed draw test');

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -511,6 +511,7 @@ test.describe('BananaTape Editor', () => {
     const boxBtn = page.locator('button[title="Box (3)"]');
     const arrowBtn = page.locator('button[title="Arrow (4)"]');
     const memoBtn = page.locator('button[title="Sticky memo (5)"]');
+    const magicBtn = page.locator('button[title="Magic Layer (7)"]');
     await penBtn.click();
     await expect(penBtn).toHaveClass(/bg-/);
 
@@ -523,6 +524,8 @@ test.describe('BananaTape Editor', () => {
     await memoBtn.click();
     await expect(memoBtn).toHaveClass(/bg-/);
 
+    await magicBtn.click();
+    await expect(magicBtn).toHaveClass(/bg-/);
 
     await page.keyboard.press('1');
     await expect(panBtn).toHaveClass(/bg-/);
@@ -535,6 +538,9 @@ test.describe('BananaTape Editor', () => {
 
     await page.keyboard.press('5');
     await expect(memoBtn).toHaveClass(/bg-/);
+
+    await page.keyboard.press('7');
+    await expect(magicBtn).toHaveClass(/bg-/);
 
     await page.keyboard.press('Escape');
     await expect(panBtn).toHaveClass(/bg-/);
@@ -1041,6 +1047,54 @@ test.describe('BananaTape Editor', () => {
     await expect(page.locator('[data-testid="composer-reference-list"]')).toBeVisible();
   });
 
+
+  test('Magic Layer segments generated image into draggable removable elements', async ({ page }) => {
+    await page.route('/api/magic-layer', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          source: 'sam3',
+          segments: [
+            { id: 'headline', label: 'Detected text', bbox: { x: 10, y: 10, width: 40, height: 24 } },
+            { id: 'subject', label: 'Subject', bbox: { x: 45, y: 45, width: 42, height: 42 } },
+          ],
+        }),
+      });
+    });
+
+    const promptInput = getPromptInput(page);
+    await promptInput.fill('magic layer test');
+    await getGenerateButton(page).click();
+    await expect(page.getByAltText('Canvas base')).toHaveAttribute('src', FAKE_IMAGE_DATA_URL);
+
+    await page.locator('button[title="Segment selected image into draggable Magic Layers"]').click();
+    const overlay = page.locator('[data-testid="magic-layer-overlay"]');
+    await expect(overlay).toBeVisible();
+    await expect(page.locator('[data-testid="magic-layer-item"]')).toHaveCount(2);
+
+    const magicTool = page.locator('button[title="Magic Layer (7)"]');
+    await magicTool.click();
+    await expect(magicTool).toHaveClass(/bg-/);
+
+    const layer = page.locator('[data-testid="magic-layer-item"][data-magic-layer-id="headline"]');
+    const before = await layer.boundingBox();
+    if (!before) throw new Error('Magic layer was not visible');
+    await page.mouse.move(before.x + before.width / 2, before.y + before.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(before.x + before.width / 2 + 60, before.y + before.height / 2 + 30, { steps: 6 });
+    await page.mouse.up();
+
+    await expect.poll(async () => {
+      const after = await layer.boundingBox();
+      return after ? Math.round(after.x - before.x) : 0;
+    }).toBeGreaterThan(20);
+
+    await page.keyboard.press('Backspace');
+    await expect(layer).toHaveCount(0);
+  });
+
   test('draws pen stroke after zooming', async ({ page }) => {
     const promptInput = getPromptInput(page);
     await promptInput.fill('zoomed draw test');
@@ -1135,14 +1189,15 @@ test.describe('BananaTape Editor', () => {
     await promptInput.fill('initial red');
     await getGenerateButton(page).click();
 
-    const baseImage = page.getByAltText('Canvas base');
+    const baseImage = page.getByAltText('Canvas base').last();
     await expect(baseImage).toHaveAttribute('src', RED_IMAGE_DATA_URL);
 
     await promptInput.fill('first edit');
     await getEditButton(page).click();
     await expect(baseImage).toHaveAttribute('src', BLUE_IMAGE_DATA_URL);
     await page.waitForFunction(() => {
-      const img = document.querySelector('img[alt="Canvas base"]') as HTMLImageElement | null;
+      const images = Array.from(document.querySelectorAll('img[alt="Canvas base"]')) as HTMLImageElement[];
+      const img = images.at(-1);
       return img?.complete && img.naturalWidth === 4;
     });
 

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -1049,36 +1049,30 @@ test.describe('BananaTape Editor', () => {
 
 
   test('Magic Layer segments generated image into draggable removable elements', async ({ page }) => {
-    await page.route('/api/magic-layer', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          success: true,
-          source: 'sam3',
-          segments: [
-            { id: 'headline', label: 'Detected text', bbox: { x: 10, y: 10, width: 40, height: 24 } },
-            { id: 'subject', label: 'Subject', bbox: { x: 45, y: 45, width: 42, height: 42 } },
-          ],
-        }),
-      });
-    });
-
     const promptInput = getPromptInput(page);
     await promptInput.fill('magic layer test');
     await getGenerateButton(page).click();
     await expect(page.getByAltText('Canvas base')).toHaveAttribute('src', FAKE_IMAGE_DATA_URL);
 
+    const magicResponse = page.waitForResponse((response) => response.url().includes('/api/magic-layer') && response.request().method() === 'POST');
     await page.locator('button[title="Segment selected image into draggable Magic Layers"]').click();
+    const response = await magicResponse;
+    expect(response.ok()).toBeTruthy();
+    const payload = await response.json();
+    expect(payload.source).toBe('fallback');
+    expect(payload.segments.length).toBeGreaterThan(0);
+
     const overlay = page.locator('[data-testid="magic-layer-overlay"]');
     await expect(overlay).toBeVisible();
-    await expect(page.locator('[data-testid="magic-layer-item"]')).toHaveCount(2);
+    await expect(page.locator('[data-testid="magic-layer-item"]')).toHaveCount(payload.segments.length);
 
     const magicTool = page.locator('button[title="Magic Layer (7)"]');
     await magicTool.click();
     await expect(magicTool).toHaveClass(/bg-/);
 
-    const layer = page.locator('[data-testid="magic-layer-item"][data-magic-layer-id="headline"]');
+    const firstLayerId = await page.locator('[data-testid="magic-layer-item"]').first().getAttribute('data-magic-layer-id');
+    if (!firstLayerId) throw new Error('Magic layer id missing');
+    const layer = page.locator(`[data-testid="magic-layer-item"][data-magic-layer-id="${firstLayerId}"]`);
     const before = await layer.boundingBox();
     if (!before) throw new Error('Magic layer was not visible');
     await page.mouse.move(before.x + before.width / 2, before.y + before.height / 2);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    exclude: ['tests/e2e/**', 'node_modules/**', '.omx/**'],
+    exclude: ['tests/e2e/**', 'node_modules/**', '.next/**', '.omx/**'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add Magic Layer segmentation API with BANANATAPE_SAM3_COMMAND SAM3 wrapper support plus local fallback segments
- add editor UI/tooling to segment a focused image into draggable/hidable cutout layers
- include Magic Layer state in canvas undo/export flows and document macOS SAM3 setup
- improve project history hydration and latest-edit focus so branch history/export tests have stable targets
- **NEW: add an Apply button on the focused image that auto-regenerates an edit using the rearranged composition as the reference + the original prompt + an inpaint instruction**

## Magic Layer Apply (new flow)
Once a user moves or hides cutouts on a Magic Layer image, a fuchsia **Apply** pill appears in the image's top-right corner (left of the existing Delete X, no overlap). Clicking it composes `image.prompt + MAGIC_LAYER_INPAINT_INSTRUCTION`, then routes through the existing `useParallelGenerate.generate({ parentIds: [imageId], ... })` pipeline so the rearranged composite (base + moved cutouts) is sent as both `original` and `annotated` to `/api/edit`. The result is a new child image with `parentId` set to the source, automatically added to history — exactly like clicking the manual Edit button.

Button gating:
- only renders when Magic Layer tool is active, the image has cutouts, and at least one cutout has been moved (`position !== sourceBounds`) or hidden
- disabled while the image is not in `'ready'` status or while the apply call is in flight
- single button per image — multiple cutouts can be rearranged and committed together

New files:
- `src/lib/prompt/magic-layer-inpaint.ts` (+ test) — inpaint instruction constant and prompt composer
- `src/lib/canvas/magic-layer-changes.ts` (+ test) — pure `hasMagicLayerChanges` / `isLayerMoved` predicates
- `src/hooks/useMagicLayerApply.ts` (+ test) — apply trigger hook wired to `useParallelGenerate`
- `src/components/Canvas/MagicLayerApplyButton.test.tsx` — button visibility / disabled / click coverage

Modified:
- `src/components/Canvas/CanvasImageItem.tsx` — render Apply pill inside `MagicLayerOverlay`
- `tests/e2e/editor.spec.ts` — new e2e covering the full Apply flow + geometry assertions (top-half + right-anchored + no Delete overlap)

## Validation
- `npm run typecheck` — clean
- `npm run lint` — 0 errors (pre-existing `<img>` warnings unchanged)
- `npx vitest run` — **255/255 pass** (25 test files), includes 8 hook tests + 7 component tests + 5+9 utility tests
- `npx playwright test tests/e2e/editor.spec.ts -g "Magic Layer"` — **2/2 pass** (drag/hide regression + new Apply flow with geometry verification)
- `npm run build` — passes

## Notes
- Real SAM3 weights/wrapper are not present in this environment, so the route was validated through the command boundary/fallback and mocked SAM3 Playwright response.
- Apply flow reuses the existing `exportImageWithAnnotations` helper which already composites magic-layer base + moved cutouts into a single PNG — no new compositing code was needed.
- One button per image (not per cutout) lets users rearrange several layers and commit them with a single API call.